### PR TITLE
Pinned (and updated where applicable) devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,17 +25,17 @@
   },
   "homepage": "http://thinktecture.com/relayserver",
   "devDependencies": {
-    "chalk": "^1.1.1",
-    "del": "^2.2.0",
-    "gitbook": "^2.6.4",
-    "gulp": "^3.9.0",
-    "gulp-github-release": "1.1.2",
-    "gulp-inject": "^3.0.0",
-    "gulp-less": "^3.0.5",
-    "gulp-rename": "^1.2.2",
-    "gulp-server-livereload": "^1.5.4",
-    "gulp-zip": "^3.0.2",
-    "q": "^1.4.1",
-    "run-sequence": "^1.1.5"
+    "chalk": "1.1.3",
+    "del": "2.2.2",
+    "gitbook": "2.6.4",
+    "gulp": "3.9.1",
+    "gulp-github-release": "1.2.0",
+    "gulp-inject": "3.0.0",
+    "gulp-less": "3.3.0",
+    "gulp-rename": "1.2.2",
+    "gulp-server-livereload": "1.9.2",
+    "gulp-zip": "3.2.0",
+    "q": "1.4.1",
+    "run-sequence": "1.2.2"
   }
 }


### PR DESCRIPTION
Since the dev dependencies where upgradable, this lead to using a new, not working version of gulp-inject. When pinning all versions, an incompatibility between the versions arose too.
The pinned set of dependencies in this PR is installable and does work.