### PR TITLE
Fixed reconnection issue with doubled-queued reconnects

### DIFF
--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnection.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnection.cs
@@ -160,7 +160,8 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 				catch (Exception ex)
 				{
 					var randomWaitTime = GetRandomWaitTime();
-					_logger.Info(ex, "Could not connect and authenticate to relay server - re-trying in {0} seconds", randomWaitTime.TotalSeconds);
+                    _logger.Info("Could not authenticate with relay server - re-trying in {0} seconds", randomWaitTime.TotalSeconds);
+                    _logger.Trace(ex, "Could not authenticate with relay server - re-trying in {0} seconds", randomWaitTime.TotalSeconds);
 					Thread.Sleep(randomWaitTime);
 				}
 			}
@@ -189,10 +190,10 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 				await Start();
 				_logger.Info("Connected to relay server #{0}", _id);
 			}
-			catch
+			catch (Exception ex)
 			{
-				_logger.Info("Error while connecting to relay server #{0}", _id);
-				await Task.Delay(5000).ContinueWith(_ => Start());
+                _logger.Info("Error while connecting to relay server #{0}", _id);
+                _logger.Trace(ex, "Error while connecting to relay server #{0}", _id);
 			}
 		}
 
@@ -520,11 +521,12 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 
 			base.OnClosed();
 
-			if (!_stopRequested)
-			{
-				_logger.Debug("Reconnecting in 5 seconds");
-				Task.Delay(5000).ContinueWith(_ => Connect());
-			}
+            if (!_stopRequested)
+            {
+                var randomWaitTime = GetRandomWaitTime();
+                _logger.Debug("Reconnecting in {0} seconds", randomWaitTime.TotalSeconds);
+                Task.Delay(randomWaitTime).ContinueWith(_ => Connect());
+            }
 		}
 
 		public Task<HttpResponseMessage> GetToRelay(string relativeUrl, CancellationToken cancellationToken)


### PR DESCRIPTION
When a connect to the relay server failed on the authentication stage (server not available, returned no token or auth failed), the code does not start the connection ( the `await Start();` call in the `Connect()` method). This is fine so far.

If, however, the call to `Start()` was already issued and fails, because the relay server died or does not accept (external) connections, then, at first, the SignalR library  internally calls the `OnClosed()` method, which issues an `Task.Delay(5000).ContinueWith(_ => Connect());` in line 396.
After that SignalR raises he exception for that failure, causing our old code in the `Connect()` method to catch it and issue the ``, too.

Now we have one delayed task that will call `Connect()` (and within that `Start()`)from the `OnClosed`, and one delayed Task that will call `Start()` directly from within our exception handler. With every further failure that is encountered, every further invocation of `OnClosed` will add one additional connect try each 5 seconds, which will in turn also try to reconnect again.

You can see that in the log and the application becoming unresponsive on the console (due to massive logging) in this case.

Bugfix is to simply remove the additional call to `Start()` in the exception handler in `Connect()`, and simply let the `OnClosed()` logic do the reconnect handling. This will also make sure that when the Relay Server has OnPremise connections turned off, the token will not be kept forever, but will be renewed before each reconnection try.