### PR TITLE
feature/localModules

### DIFF
--- a/Documentation/de/3-installation.md
+++ b/Documentation/de/3-installation.md
@@ -144,9 +144,9 @@ Die Standardeinstellungen umfassen dabei:
 
 |  Key name | Description |
 | --- | --- |
-| EnableManagementWeb | Aktiviert die Management Weboberfläche (default true) |
-| EnableRelaying | Aktiviert die Relay-Funktion des Servers (default true) |
-| EnableOnPremiseConnections | Erlaubt den Verbindungsaufbau von On-Premises Connectoren (default true) |
+| EnableManagementWeb | Aktiviert die Management Weboberfläche (default true) <br/> Mögliche Werte: true (an), false (aus), local (es werden nur Anfragen von localhost beantwortet)
+| EnableRelaying | Aktiviert die Relay-Funktion des Servers (default true) <br/> Mögliche Werte: true (an), false (aus), local (es werden nur Anfragen von localhost beantwortet)|
+| EnableOnPremiseConnections | Erlaubt den Verbindungsaufbau von On-Premises Connectoren (default true) <br/> Mögliche Werte: true (an), false (aus), local (es werden nur Anfragen von localhost beantwortet)|
 | Port | Standard-Port des RelayServers (default 443) |
 | HostName | Gewünschte Ziel-URL des RelayServers (default +) |
 | UseInsecureHttp | Aktiviert die Verwendung von HTTP statt HTTPS (die Verwendung von HTTP im Produktivbetrieb wird nicht empfohlen). |

--- a/Thinktecture.Relay.Server.Test/Diagnostics/TraceManagerTest.cs
+++ b/Thinktecture.Relay.Server.Test/Diagnostics/TraceManagerTest.cs
@@ -41,9 +41,9 @@ namespace Thinktecture.Relay.Server.Diagnostics
 			public int ConnectionTimeout { get; private set; }
 			public int KeepAliveInterval { get; private set; }
 			public bool UseInsecureHttp { get; private set; }
-			public bool EnableManagementWeb { get; private set; }
-			public bool EnableRelaying { get; private set; }
-			public bool EnableOnPremiseConnections { get; private set; }
+			public ModuleBinding EnableManagementWeb { get; private set; }
+			public ModuleBinding EnableRelaying { get; private set; }
+			public ModuleBinding EnableOnPremiseConnections { get; private set; }
 			public string HostName { get; private set; }
 			public int Port { get; private set; }
 			public string ManagementWebLocation { get; private set; }

--- a/Thinktecture.Relay.Server/Configuration/Configuration.cs
+++ b/Thinktecture.Relay.Server/Configuration/Configuration.cs
@@ -14,9 +14,9 @@ namespace Thinktecture.Relay.Server.Configuration
 		public int ConnectionTimeout { get; private set; }
 		public int KeepAliveInterval { get; private set; }
 		public bool UseInsecureHttp { get; private set; }
-		public bool EnableManagementWeb { get; private set; }
-		public bool EnableRelaying { get; private set; }
-		public bool EnableOnPremiseConnections { get; private set; }
+		public ModuleBinding EnableManagementWeb { get; private set; }
+		public ModuleBinding EnableRelaying { get; private set; }
+		public ModuleBinding EnableOnPremiseConnections { get; private set; }
 		public string HostName { get; private set; }
 		public int Port { get; private set; }
 		public string ManagementWebLocation { get; private set; }
@@ -25,6 +25,7 @@ namespace Thinktecture.Relay.Server.Configuration
 		{
 			int tmpInt;
 			bool tmpBool;
+			ModuleBinding tmpModuleBinding;
 
 			if (!Int32.TryParse(ConfigurationManager.AppSettings["OnPremiseConnectorCallbackTimeout"], out tmpInt))
 			{
@@ -72,22 +73,22 @@ namespace Thinktecture.Relay.Server.Configuration
 				Port = tmpInt;
 			}
 
-			EnableManagementWeb = true;
-			if (Boolean.TryParse(ConfigurationManager.AppSettings["EnableManagementWeb"], out tmpBool))
+			EnableManagementWeb = ModuleBinding.True;
+			if (Enum.TryParse(ConfigurationManager.AppSettings["EnableManagementWeb"], true, out tmpModuleBinding))
 			{
-				EnableManagementWeb = tmpBool;
+				EnableManagementWeb = tmpModuleBinding;
 			}
 
-			EnableRelaying = true;
-			if (Boolean.TryParse(ConfigurationManager.AppSettings["EnableRelaying"], out tmpBool))
+			EnableRelaying = ModuleBinding.True;
+			if (Enum.TryParse(ConfigurationManager.AppSettings["EnableRelaying"], true, out tmpModuleBinding))
 			{
-				EnableRelaying = tmpBool;
+				EnableRelaying = tmpModuleBinding;
 			}
 
-			EnableOnPremiseConnections = true;
-			if (Boolean.TryParse(ConfigurationManager.AppSettings["EnableOnPremiseConnections"], out tmpBool))
+			EnableOnPremiseConnections = ModuleBinding.True;
+			if (Enum.TryParse(ConfigurationManager.AppSettings["EnableOnPremiseConnections"], true, out tmpModuleBinding))
 			{
-				EnableOnPremiseConnections = tmpBool;
+				EnableOnPremiseConnections = tmpModuleBinding;
 			}
 
 			UseInsecureHttp = false;

--- a/Thinktecture.Relay.Server/Configuration/IConfiguration.cs
+++ b/Thinktecture.Relay.Server/Configuration/IConfiguration.cs
@@ -12,9 +12,9 @@ namespace Thinktecture.Relay.Server.Configuration
 		int ConnectionTimeout { get; }
 		int KeepAliveInterval { get; }
 		bool UseInsecureHttp { get; }
-		bool EnableManagementWeb { get; }
-		bool EnableRelaying { get; }
-		bool EnableOnPremiseConnections { get; }
+		ModuleBinding EnableManagementWeb { get; }
+		ModuleBinding EnableRelaying { get; }
+		ModuleBinding EnableOnPremiseConnections { get; }
 		string HostName { get; }
 		int Port { get; }
 		string ManagementWebLocation { get; }

--- a/Thinktecture.Relay.Server/Configuration/ModuleState.cs
+++ b/Thinktecture.Relay.Server/Configuration/ModuleState.cs
@@ -1,0 +1,9 @@
+﻿namespace Thinktecture.Relay.Server.Configuration
+{
+	public enum ModuleBinding
+	{
+		False,
+		True,
+		Local,
+	}
+}

--- a/Thinktecture.Relay.Server/Controller/CheckModuleBindingConfigurationAttribute.cs
+++ b/Thinktecture.Relay.Server/Controller/CheckModuleBindingConfigurationAttribute.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+using Thinktecture.Relay.Server.Configuration;
+
+namespace Thinktecture.Relay.Server.Controller
+{
+	public class CheckModuleBindingConfigurationAttribute : ActionFilterAttribute
+	{
+		public override bool AllowMultiple => true;
+
+		public IConfiguration Configuration { get; set; }
+		private readonly Func<IConfiguration, ModuleBinding> _getPropertyFunc;
+
+		public CheckModuleBindingConfigurationAttribute(Func<IConfiguration, ModuleBinding> getPropertyFunc)
+		{
+			_getPropertyFunc = getPropertyFunc;
+		}
+
+
+		public override void OnActionExecuting(HttpActionContext actionContext)
+		{
+			var value = _getPropertyFunc(Configuration);
+
+			if ((value == ModuleBinding.False) || (value == ModuleBinding.Local && !actionContext.Request.IsLocal()))
+			{
+				throw new HttpResponseException(new HttpResponseMessage(HttpStatusCode.NotFound));
+			}
+		}
+	}
+}

--- a/Thinktecture.Relay.Server/Controller/ClientController.cs
+++ b/Thinktecture.Relay.Server/Controller/ClientController.cs
@@ -14,6 +14,7 @@ using Thinktecture.Relay.Server.Repository;
 namespace Thinktecture.Relay.Server.Controller
 {
     [AllowAnonymous]
+    [RelayModuleBindingFilter]
     public class ClientController : ApiController
     {
         private readonly IBackendCommunication _backendCommunication;

--- a/Thinktecture.Relay.Server/Controller/ManagementWeb/DashboardController.cs
+++ b/Thinktecture.Relay.Server/Controller/ManagementWeb/DashboardController.cs
@@ -5,6 +5,7 @@ using Thinktecture.Relay.Server.Repository;
 namespace Thinktecture.Relay.Server.Controller.ManagementWeb
 {
     [Authorize(Roles = "Admin")]
+    [ManagementWebModuleBindingFilter]
     public class DashboardController : ApiController
     {
         private readonly ILogRepository _logRepository;

--- a/Thinktecture.Relay.Server/Controller/ManagementWeb/FakeDataController.cs
+++ b/Thinktecture.Relay.Server/Controller/ManagementWeb/FakeDataController.cs
@@ -8,6 +8,7 @@ using Thinktecture.Relay.Server.Repository;
 namespace Thinktecture.Relay.Server.Controller.ManagementWeb
 {
     [AllowAnonymous]
+    [ManagementWebModuleBindingFilter]
     public class FakeDataController : ApiController
     {
         private readonly IUserRepository _userRepository;

--- a/Thinktecture.Relay.Server/Controller/ManagementWeb/LinkController.cs
+++ b/Thinktecture.Relay.Server/Controller/ManagementWeb/LinkController.cs
@@ -11,6 +11,7 @@ using Thinktecture.Relay.Server.Repository;
 namespace Thinktecture.Relay.Server.Controller.ManagementWeb
 {
     [Authorize(Roles = "Admin")]
+    [ManagementWebModuleBindingFilter]
     public class LinkController : ApiController
     {
         private readonly ILinkRepository _linkRepository;

--- a/Thinktecture.Relay.Server/Controller/ManagementWeb/LogController.cs
+++ b/Thinktecture.Relay.Server/Controller/ManagementWeb/LogController.cs
@@ -5,6 +5,7 @@ using Thinktecture.Relay.Server.Repository;
 
 namespace Thinktecture.Relay.Server.Controller.ManagementWeb
 {
+    [ManagementWebModuleBindingFilter]
     public class LogController : ApiController
     {
         private readonly ILogRepository _logRepository;

--- a/Thinktecture.Relay.Server/Controller/ManagementWeb/SetupController.cs
+++ b/Thinktecture.Relay.Server/Controller/ManagementWeb/SetupController.cs
@@ -6,6 +6,7 @@ using Thinktecture.Relay.Server.Repository;
 namespace Thinktecture.Relay.Server.Controller.ManagementWeb
 {
     [AllowAnonymous]
+    [ManagementWebModuleBindingFilter]
     public class SetupController : ApiController
     {
         private readonly IUserRepository _userRepository;

--- a/Thinktecture.Relay.Server/Controller/ManagementWeb/TraceController.cs
+++ b/Thinktecture.Relay.Server/Controller/ManagementWeb/TraceController.cs
@@ -9,6 +9,7 @@ using Thinktecture.Relay.Server.Repository;
 namespace Thinktecture.Relay.Server.Controller.ManagementWeb
 {
 	[Authorize(Roles = "Admin")]
+	[ManagementWebModuleBindingFilter]
 	public class TraceController : ApiController
 	{
 		private readonly ITraceRepository _traceRepository;

--- a/Thinktecture.Relay.Server/Controller/ManagementWeb/UserController.cs
+++ b/Thinktecture.Relay.Server/Controller/ManagementWeb/UserController.cs
@@ -9,6 +9,7 @@ using Thinktecture.Relay.Server.Repository;
 namespace Thinktecture.Relay.Server.Controller.ManagementWeb
 {
     [Authorize(Roles = "Admin")]
+    [ManagementWebModuleBindingFilter]
     public class UserController : ApiController
     {
         private readonly IUserRepository _userRepository;

--- a/Thinktecture.Relay.Server/Controller/ManagementWebModuleBindingFilter.cs
+++ b/Thinktecture.Relay.Server/Controller/ManagementWebModuleBindingFilter.cs
@@ -1,0 +1,10 @@
+namespace Thinktecture.Relay.Server.Controller
+{
+	public class ManagementWebModuleBindingFilter : CheckModuleBindingConfigurationAttribute
+	{
+		public ManagementWebModuleBindingFilter()
+			: base(c => c.EnableManagementWeb)
+		{
+		}
+	}
+}

--- a/Thinktecture.Relay.Server/Controller/OnPremiseConnectionModuleBindingFilter.cs
+++ b/Thinktecture.Relay.Server/Controller/OnPremiseConnectionModuleBindingFilter.cs
@@ -1,0 +1,10 @@
+namespace Thinktecture.Relay.Server.Controller
+{
+	public class OnPremiseConnectionModuleBindingFilter : CheckModuleBindingConfigurationAttribute
+	{
+		public OnPremiseConnectionModuleBindingFilter()
+			: base(c => c.EnableOnPremiseConnections)
+		{
+		}
+	}
+}

--- a/Thinktecture.Relay.Server/Controller/RelayModuleBindingFilter.cs
+++ b/Thinktecture.Relay.Server/Controller/RelayModuleBindingFilter.cs
@@ -1,0 +1,10 @@
+namespace Thinktecture.Relay.Server.Controller
+{
+	public class RelayModuleBindingFilter : CheckModuleBindingConfigurationAttribute
+	{
+		public RelayModuleBindingFilter()
+			: base(c => c.EnableRelaying)
+		{
+		}
+	}
+}

--- a/Thinktecture.Relay.Server/Controller/RequestController.cs
+++ b/Thinktecture.Relay.Server/Controller/RequestController.cs
@@ -6,6 +6,8 @@ using Thinktecture.Relay.Server.SignalR;
 
 namespace Thinktecture.Relay.Server.Controller
 {
+    [Authorize(Roles = "OnPremise")]
+    [OnPremiseConnectionModuleBindingFilter]
     public class RequestController : ApiController
     {
         private readonly IPostDataTemporaryStore _temporaryStore;

--- a/Thinktecture.Relay.Server/Controller/ResponseController.cs
+++ b/Thinktecture.Relay.Server/Controller/ResponseController.cs
@@ -10,6 +10,7 @@ using Thinktecture.Relay.Server.Communication;
 namespace Thinktecture.Relay.Server.Controller
 {
     [Authorize(Roles = "OnPremise")]
+    [OnPremiseConnectionModuleBindingFilter]
     public class ResponseController : ApiController
     {
         private readonly ILogger _logger;

--- a/Thinktecture.Relay.Server/Owin/BlockNonLocalRequestsMiddleware.cs
+++ b/Thinktecture.Relay.Server/Owin/BlockNonLocalRequestsMiddleware.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Owin;
+
+namespace Thinktecture.Relay.Server.Owin
+{
+	class BlockNonLocalRequestsMiddleware : OwinMiddleware
+	{
+		private readonly string _path;
+		
+		public BlockNonLocalRequestsMiddleware(OwinMiddleware next, string path)
+			: base(next)
+		{
+			_path = path;
+		}
+
+		public override async Task Invoke(IOwinContext context)
+		{
+			if (context.Request.Uri.PathAndQuery.StartsWith(_path, StringComparison.InvariantCultureIgnoreCase) && !context.Request.Uri.IsLoopback)
+			{
+				context.Response.StatusCode = 404;
+				context.Response.Body.Flush();
+			}
+			else
+			{
+				await Next.Invoke(context);
+			}
+		}
+	}
+}

--- a/Thinktecture.Relay.Server/Startup.cs
+++ b/Thinktecture.Relay.Server/Startup.cs
@@ -109,17 +109,17 @@ namespace Thinktecture.Relay.Server
 
 			var builder = new ContainerBuilder();
 
-			if (configuration.EnableManagementWeb)
+			if (configuration.EnableManagementWeb != ModuleBinding.False)
 			{
 				builder.RegisterModule<ManagementWebModule>();
 			}
 
-			if (configuration.EnableRelaying)
+			if (configuration.EnableRelaying != ModuleBinding.False)
 			{
 				builder.RegisterModule<RelayingModule>();
 			}
 
-			if (configuration.EnableOnPremiseConnections)
+			if (configuration.EnableOnPremiseConnections != ModuleBinding.False)
 			{
 				builder.RegisterModule<OnPremiseConnectionsModule>();
 			}
@@ -194,7 +194,7 @@ namespace Thinktecture.Relay.Server
 		{
 			var config = container.Resolve<IConfiguration>();
 
-			if (!config.EnableOnPremiseConnections)
+			if (config.EnableOnPremiseConnections == ModuleBinding.False)
 			{
 				return;
 			}
@@ -233,20 +233,20 @@ namespace Thinktecture.Relay.Server
 			httpConfig.Filters.Add(new NLogActionFilter(logger));
 			httpConfig.Filters.Add(new HostAuthenticationFilter(OAuthDefaults.AuthenticationType));
 
-			if (configuration.EnableRelaying)
+			if (configuration.EnableRelaying != ModuleBinding.False)
 			{
 				logger.Info("Relaying enabled");
 				httpConfig.Routes.MapHttpRoute("ClientRequest", "relay/{*path}", new {controller = "Client", action = "Relay"});
 			}
 
-			if (configuration.EnableOnPremiseConnections)
+			if (configuration.EnableOnPremiseConnections != ModuleBinding.False)
 			{
 				logger.Info("On-premise connections enabled");
 				httpConfig.Routes.MapHttpRoute("OnPremiseTargetResponse", "forward", new {controller = "Response", action = "Forward"});
 				httpConfig.Routes.MapHttpRoute("OnPremiseTargetRequest", "request/{requestId}", new {controller = "Request", action = "Get"});
 			}
 
-			if (configuration.EnableManagementWeb)
+			if (configuration.EnableManagementWeb != ModuleBinding.False)
 			{
 				logger.Info("Management web enabled");
 				httpConfig.Routes.MapHttpRoute("ManagementWeb", "api/managementweb/{controller}/{action}");
@@ -262,7 +262,7 @@ namespace Thinktecture.Relay.Server
 			var configuration = container.Resolve<IConfiguration>();
 			var logger = container.Resolve<ILogger>();
 
-			if (!configuration.EnableManagementWeb)
+			if (configuration.EnableManagementWeb == ModuleBinding.False)
 			{
 				return;
 			}

--- a/Thinktecture.Relay.Server/Startup.cs
+++ b/Thinktecture.Relay.Server/Startup.cs
@@ -209,7 +209,7 @@ namespace Thinktecture.Relay.Server
 			});
 		}
 
-		private static void UseWebApi(IAppBuilder app, ILifetimeScope container)
+		private static void UseWebApi(IAppBuilder app, IContainer container)
 		{
 			var configuration = container.Resolve<IConfiguration>();
 			var logger = container.Resolve<ILogger>();
@@ -253,6 +253,10 @@ namespace Thinktecture.Relay.Server
 			}
 
 			httpConfig.Formatters.JsonFormatter.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+
+			var builder = new ContainerBuilder();
+			builder.RegisterWebApiFilterProvider(httpConfig);
+			builder.Update(container);
 
 			app.UseWebApi(httpConfig);
 		}

--- a/Thinktecture.Relay.Server/Thinktecture.Relay.Server.csproj
+++ b/Thinktecture.Relay.Server/Thinktecture.Relay.Server.csproj
@@ -202,7 +202,9 @@
     <Compile Include="Communication\UnregistrationAction.cs" />
     <Compile Include="Communication\RegistrationInformation.cs" />
     <Compile Include="Configuration\ModuleState.cs" />
+    <Compile Include="Controller\CheckModuleBindingConfigurationAttribute.cs" />
     <Compile Include="Controller\OnPremiseConnectionsModule.cs" />
+    <Compile Include="Controller\RelayModuleBindingFilter.cs" />
     <Compile Include="Security\CustomJwtFormat.cs" />
     <Compile Include="Dto\ContentBytesChartGroupKey.cs" />
     <Compile Include="Filters\NLogActionFilter.cs" />

--- a/Thinktecture.Relay.Server/Thinktecture.Relay.Server.csproj
+++ b/Thinktecture.Relay.Server/Thinktecture.Relay.Server.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Communication\RegistrationInformation.cs" />
     <Compile Include="Configuration\ModuleState.cs" />
     <Compile Include="Controller\CheckModuleBindingConfigurationAttribute.cs" />
+    <Compile Include="Controller\ManagementWebModuleBindingFilter.cs" />
     <Compile Include="Controller\OnPremiseConnectionModuleBindingFilter.cs" />
     <Compile Include="Controller\OnPremiseConnectionsModule.cs" />
     <Compile Include="Controller\RelayModuleBindingFilter.cs" />

--- a/Thinktecture.Relay.Server/Thinktecture.Relay.Server.csproj
+++ b/Thinktecture.Relay.Server/Thinktecture.Relay.Server.csproj
@@ -191,6 +191,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Owin\BlockNonLocalRequestsMiddleware.cs" />
     <Compile Include="Communication\ConnectionInformation.cs" />
     <Compile Include="Communication\IMessageDispatcher.cs" />
     <Compile Include="Communication\InProcess\InProcessMessageDispatcher.cs" />

--- a/Thinktecture.Relay.Server/Thinktecture.Relay.Server.csproj
+++ b/Thinktecture.Relay.Server/Thinktecture.Relay.Server.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Communication\RegistrationAction.cs" />
     <Compile Include="Communication\UnregistrationAction.cs" />
     <Compile Include="Communication\RegistrationInformation.cs" />
+    <Compile Include="Configuration\ModuleState.cs" />
     <Compile Include="Controller\OnPremiseConnectionsModule.cs" />
     <Compile Include="Security\CustomJwtFormat.cs" />
     <Compile Include="Dto\ContentBytesChartGroupKey.cs" />

--- a/Thinktecture.Relay.Server/Thinktecture.Relay.Server.csproj
+++ b/Thinktecture.Relay.Server/Thinktecture.Relay.Server.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Communication\RegistrationInformation.cs" />
     <Compile Include="Configuration\ModuleState.cs" />
     <Compile Include="Controller\CheckModuleBindingConfigurationAttribute.cs" />
+    <Compile Include="Controller\OnPremiseConnectionModuleBindingFilter.cs" />
     <Compile Include="Controller\OnPremiseConnectionsModule.cs" />
     <Compile Include="Controller\RelayModuleBindingFilter.cs" />
     <Compile Include="Security\CustomJwtFormat.cs" />


### PR DESCRIPTION
Modules (relay, managementweb and onpremise connections) can now individually be configured to only accept local requests.