### PR TITLE
Bugfix: Also copy over the content headers of the response message

### DIFF
--- a/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseWebTargetConnector.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseWebTargetConnector.cs
@@ -152,7 +152,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 				var message = await CreateLocalTargetRequestAsync(url, request, relayedRequestHeader).ConfigureAwait(false);
 
 				response.StatusCode = message.StatusCode;
-				response.HttpHeaders = message.Headers.ToDictionary(kvp => kvp.Key, kvp => String.Join(" ", kvp.Value));
+				response.HttpHeaders = message.Headers.Union(message.Content.Headers).ToDictionary(kvp => kvp.Key, kvp => String.Join(" ", kvp.Value));
 				response.Stream = await message.Content.ReadAsStreamAsync().ConfigureAwait(false);
 				response.HttpResponseMessage = message;
 			}


### PR DESCRIPTION
Because thats for example the place where content-encoding (i.e. gzip) lives ;)