### PR TITLE
Don't follow local redirects but optionally relay them instead

### DIFF
--- a/Documentation/de/3-installation.md
+++ b/Documentation/de/3-installation.md
@@ -291,7 +291,7 @@ In der Konfigurationsdatei muss nur der Abschnitt <relayServer></relayServer> be
     <identity userName="userName" password="password" />
   </security>
   <onPremiseTargets>
-    <web key="Test" baseUrl="http://localhost/"/>
+    <web key="Test" baseUrl="http://localhost/" relayRedirects="false" />
   </onPremiseTargets>
 </relayServer>
 ```
@@ -322,7 +322,10 @@ In der Konfigurationsdatei muss nur der Abschnitt <relayServer></relayServer> be
 
 Liste von On-Premises Applikationen, die vom On-Premises Connector mit Anfragen versorgt werden sollen.
 
+### web Element
+
 |  Attribut | Beschreibung |
 | --- | --- |
 | key | On-Premises-Anwendungsname |
 | baseUrl | URL des On-Premises Applikation |
+| relayRedirects | Automatische lokale Weiterleitung oder Remote-Weiterleitung |

--- a/Documentation/en/3-installation.md
+++ b/Documentation/en/3-installation.md
@@ -289,7 +289,7 @@ Only the <relayServer></relayServer> section has to be edited in the configurati
     <identity userName="userName" password="password" />
   </security>
   <onPremiseTargets>
-    <web key="Test" baseUrl="http://localhost/" />
+    <web key="Test" baseUrl="http://localhost/" relayRedirects="false" />
   </onPremiseTargets>
 </relayServer>
 ```
@@ -319,3 +319,11 @@ Only the <relayServer></relayServer> section has to be edited in the configurati
 ### onPremiseTargets Element
 
 List of on-premise applications that the On-Premise Connector should be able to send requests to.
+
+### web Element
+
+|  Attribute | Description |
+| --- | --- |
+| key | On-Premise application name |
+| baseUrl | URL of the On-Premise application |
+| relayRedirects | Auto redirect locally or relay redirects |

--- a/Thinktecture.Relay.OnPremiseConnector/IRelayServerConnector.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/IRelayServerConnector.cs
@@ -22,7 +22,8 @@ namespace Thinktecture.Relay.OnPremiseConnector
 		/// </summary>
 		/// <param name="key">A <see cref="String"/> defining the key for the target.</param>
 		/// <param name="uri">An <see cref="Uri"/> containing the on-premise target's base url.</param>
-		void RegisterOnPremiseTarget(string key, Uri uri);
+		/// <param name="relayRedirects">An <see cref="bool"/> defining if the target will follow redirects or relay them.</param>
+		void RegisterOnPremiseTarget(string key, Uri uri, bool relayRedirects);
 
 		/// <summary>
 		/// Registers a on-premise in-proc target.

--- a/Thinktecture.Relay.OnPremiseConnector/Net/Http/HttpClientFactory.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/Net/Http/HttpClientFactory.cs
@@ -9,7 +9,8 @@ namespace Thinktecture.Relay.OnPremiseConnector.Net.Http
 		///<inheritdoc/>
 		public HttpClient CreateClient(String name)
 		{
-			// We ignore the name here, as this should be as simple as it gets.
+			if (name == "RedirectableWebTarget")
+				return new HttpClient(new HttpClientHandler() { AllowAutoRedirect = true});
 			return new HttpClient();
 		}
 	}

--- a/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/IOnPremiseTargetConnectorFactory.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/IOnPremiseTargetConnectorFactory.cs
@@ -4,7 +4,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 {
 	internal interface IOnPremiseTargetConnectorFactory
 	{
-		IOnPremiseTargetConnector Create(Uri baseUri, TimeSpan requestTimeout);
+		IOnPremiseTargetConnector Create(Uri baseUri, TimeSpan requestTimeout, bool relayRedirects);
 		IOnPremiseTargetConnector Create(Type handlerType, TimeSpan requestTimeout);
 		IOnPremiseTargetConnector Create(Func<IOnPremiseInProcHandler> handlerFactory, TimeSpan requestTimeout);
 		IOnPremiseTargetConnector Create<T>(TimeSpan requestTimeout) where T : IOnPremiseInProcHandler, new();

--- a/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseTargetConnectorFactory.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseTargetConnectorFactory.cs
@@ -17,9 +17,9 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 			_httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
 		}
 
-		public IOnPremiseTargetConnector Create(Uri baseUri, TimeSpan requestTimeout)
+		public IOnPremiseTargetConnector Create(Uri baseUri, TimeSpan requestTimeout, bool relayRedirects)
 		{
-			return new OnPremiseWebTargetConnector(baseUri, requestTimeout, _logger, _requestMessageBuilderFactory(), _httpClientFactory);
+			return new OnPremiseWebTargetConnector(baseUri, requestTimeout, _logger, _requestMessageBuilderFactory(), _httpClientFactory, relayRedirects);
 		}
 
 		public IOnPremiseTargetConnector Create(Type handlerType, TimeSpan requestTimeout)

--- a/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseWebTargetConnector.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseWebTargetConnector.cs
@@ -18,7 +18,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 		private readonly TimeSpan _requestTimeout;
 		private readonly HttpClient _httpClient;
 
-		public OnPremiseWebTargetConnector(Uri baseUri, TimeSpan requestTimeout, ILogger logger, IOnPremiseWebTargetRequestMessageBuilder requestMessageBuilder, IHttpClientFactory httpClientFactory)
+		public OnPremiseWebTargetConnector(Uri baseUri, TimeSpan requestTimeout, ILogger logger, IOnPremiseWebTargetRequestMessageBuilder requestMessageBuilder, IHttpClientFactory httpClientFactory, bool relayRedirects)
 		{
 			if (requestTimeout < TimeSpan.Zero)
 				throw new ArgumentOutOfRangeException(nameof(requestTimeout), "Request timeout cannot be negative.");
@@ -28,7 +28,10 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 			_logger = logger;
 			_requestMessageBuilder = requestMessageBuilder ?? throw new ArgumentNullException(nameof(requestMessageBuilder));
 
-			_httpClient = httpClientFactory.CreateClient("WebTarget");
+			if (relayRedirects)
+				_httpClient = httpClientFactory.CreateClient("RedirectableWebTarget");
+			else
+				_httpClient = httpClientFactory.CreateClient("WebTarget");
 		}
 
 		public async Task<IOnPremiseTargetResponse> GetResponseFromLocalTargetAsync(string url, IOnPremiseTargetRequest request, string relayedRequestHeader)

--- a/Thinktecture.Relay.OnPremiseConnector/RelayServerConnector.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/RelayServerConnector.cs
@@ -67,10 +67,11 @@ namespace Thinktecture.Relay.OnPremiseConnector
 		/// </summary>
 		/// <param name="key">A <see cref="String"/> defining the key for the target.</param>
 		/// <param name="uri">An <see cref="Uri"/> containing the on-premise target's base url.</param>
-		public void RegisterOnPremiseTarget(string key, Uri uri)
+		/// <param name="relayRedirects">A <see cref="bool"/> defining whether the target will follow redirects or relay them.</param>
+		public void RegisterOnPremiseTarget(string key, Uri uri, bool relayRedirects)
 		{
 			CheckDisposed();
-			_connection.RegisterOnPremiseTarget(key, uri);
+			_connection.RegisterOnPremiseTarget(key, uri, relayRedirects);
 		}
 
 		/// <summary>

--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/IRelayServerConnection.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/IRelayServerConnection.cs
@@ -19,7 +19,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 
 		event EventHandler Disposing;
 
-		void RegisterOnPremiseTarget(string key, Uri baseUri);
+		void RegisterOnPremiseTarget(string key, Uri baseUri, bool relayRedirects);
 		void RegisterOnPremiseTarget(string key, Type handlerType);
 		void RegisterOnPremiseTarget(string key, Func<IOnPremiseInProcHandler> handlerFactory);
 		void RegisterOnPremiseTarget<T>(string key) where T : IOnPremiseInProcHandler, new();

--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnection.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnection.cs
@@ -77,7 +77,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 
 		public string RelayedRequestHeader { get; set; }
 
-		public void RegisterOnPremiseTarget(string key, Uri baseUri)
+		public void RegisterOnPremiseTarget(string key, Uri baseUri, bool relayRedirects)
 		{
 			if (key == null)
 				throw new ArgumentNullException(nameof(key));
@@ -86,9 +86,9 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 
 			key = RemoveTrailingSlashes(key);
 
-			_logger?.Verbose("Registering on-premise web target. handler-key={HandlerKey}, base-uri={BaseUri}", key, baseUri);
+			_logger?.Verbose("Registering on-premise web target. handler-key={HandlerKey}, base-uri={BaseUri}, relay-redirects={RelayRedirects}", key, baseUri, relayRedirects);
 
-			_connectors[key] = _onPremiseTargetConnectorFactory.Create(baseUri, _requestTimeout);
+			_connectors[key] = _onPremiseTargetConnectorFactory.Create(baseUri, _requestTimeout, relayRedirects);
 		}
 
 		public void RegisterOnPremiseTarget(string key, Type handlerType)

--- a/Thinktecture.Relay.OnPremiseConnectorService/App.config
+++ b/Thinktecture.Relay.OnPremiseConnectorService/App.config
@@ -38,11 +38,11 @@
       <identity userName="test" password="Ydy00/DbyMuGNwFnRDEmRc5Tg4z4wdnLmroSA5rt3z1/iQJYd2ctNhjnDWVPH+vGdzTpbW6BRpiW5GQOPzEka5CyYKgH5HXqgEriSUFjEtNo0eK2syQShFHoRuJnX6F5/iZPoA==" />
     </security>
 
-		<onPremiseTargets>
-			<web key="tt" baseUrl="http://thinktecture.com/" />
-			<web key="lh" baseUrl="http://localhost/" />
-		</onPremiseTargets>
-	</relayServer>
+    <onPremiseTargets>
+      <web key="tt" baseUrl="http://thinktecture.com/" relayRedirects="false" />
+      <web key="lh" baseUrl="http://localhost/" relayRedirects="false" />
+    </onPremiseTargets>
+  </relayServer>
 
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Thinktecture.Relay.OnPremiseConnectorService/Configuration/OnPremiseWebTargetElement.cs
+++ b/Thinktecture.Relay.OnPremiseConnectorService/Configuration/OnPremiseWebTargetElement.cs
@@ -5,12 +5,15 @@ namespace Thinktecture.Relay.OnPremiseConnectorService.Configuration
 	public sealed class OnPremiseWebTargetElement : OnPremiseTargetElement
 	{
 		private readonly ConfigurationProperty _baseUrl = new ConfigurationProperty("baseUrl", typeof(string), null, ConfigurationPropertyOptions.IsRequired);
+		private readonly ConfigurationProperty _relayRedirects = new ConfigurationProperty("relayRedirects", typeof(bool), false);
 
 		public OnPremiseWebTargetElement()
 		{
 			Properties.Add(_baseUrl);
+			Properties.Add(_relayRedirects);
 		}
 
 		public string BaseUrl => (string)this[_baseUrl];
+		public bool RelayRedirects => (bool)this[_relayRedirects];
 	}
 }

--- a/Thinktecture.Relay.OnPremiseConnectorService/OnPremisesService.cs
+++ b/Thinktecture.Relay.OnPremiseConnectorService/OnPremisesService.cs
@@ -51,7 +51,7 @@ namespace Thinktecture.Relay.OnPremiseConnectorService
 
 				foreach (var onPremiseTarget in section.OnPremiseTargets.OfType<OnPremiseWebTargetElement>())
 				{
-					_connector.RegisterOnPremiseTarget(onPremiseTarget.Key, new Uri(onPremiseTarget.BaseUrl));
+					_connector.RegisterOnPremiseTarget(onPremiseTarget.Key, new Uri(onPremiseTarget.BaseUrl), onPremiseTarget.RelayRedirects);
 				}
 
 				foreach (var onPremiseTarget in section.OnPremiseTargets.OfType<OnPremiseInProcTargetElement>())

--- a/Thinktecture.Relay.Server/Http/HttpResponseMessageBuilder.cs
+++ b/Thinktecture.Relay.Server/Http/HttpResponseMessageBuilder.cs
@@ -56,9 +56,22 @@ namespace Thinktecture.Relay.Server.Http
 				{
 					message.Headers.Add("WWW-Authenticate", wwwAuthenticate);
 				}
+
+				if (IsRedirectStatusCode(response.StatusCode))
+				{
+					if (response.HttpHeaders.TryGetValue("Location", out var location))
+					{
+						message.Headers.Location = new Uri(location, UriKind.RelativeOrAbsolute);
+					}
+				}
 			}
 
 			return message;
+		}
+
+		private static bool IsRedirectStatusCode(HttpStatusCode statusCode)
+		{
+			 return ((int)statusCode >= 300) && ((int)statusCode <= 399);
 		}
 
 		public HttpContent GetResponseContentForOnPremiseTargetResponse(IOnPremiseConnectorResponse response, Link link)


### PR DESCRIPTION
Issue exists today where On-Premise Connector HttpClient follows redirects locally (i.e. HTTP status codes between 300 & 399) and if On-Premise server returns any important headers (e.g. token, cookie etc) as part of the redirect these are lost and not relayed back to the client application.