### PR TITLE
Add X-Frame-Options: DENY header to all management web file requests

### DIFF
--- a/Thinktecture.Relay.Server/Startup.cs
+++ b/Thinktecture.Relay.Server/Startup.cs
@@ -248,6 +248,11 @@ namespace Thinktecture.Relay.Server
 					app.Use(typeof(BlockNonLocalRequestsMiddleware), path);
 				}
 
+				options.StaticFileOptions.OnPrepareResponse = (ctx) =>
+				{
+					ctx.OwinContext.Response.Headers.Append("X-Frame-Options", "DENY");
+				};
+
 				app.UseFileServer(options);
 			}
 			catch (DirectoryNotFoundException)


### PR DESCRIPTION
To prevent including the management web into other malicious sites