### PR TITLE
Add X-XSS-Protection header for static files of management web

### DIFF
--- a/Thinktecture.Relay.Server/Startup.cs
+++ b/Thinktecture.Relay.Server/Startup.cs
@@ -251,6 +251,7 @@ namespace Thinktecture.Relay.Server
 				options.StaticFileOptions.OnPrepareResponse = (ctx) =>
 				{
 					ctx.OwinContext.Response.Headers.Append("X-Frame-Options", "DENY");
+					ctx.OwinContext.Response.Headers.Append("X-XSS-Protection", "1; mode=block");
 				};
 
 				app.UseFileServer(options);

--- a/Thinktecture.Relay.Server/Startup.cs
+++ b/Thinktecture.Relay.Server/Startup.cs
@@ -248,6 +248,11 @@ namespace Thinktecture.Relay.Server
 					app.Use(typeof(BlockNonLocalRequestsMiddleware), path);
 				}
 
+				options.StaticFileOptions.OnPrepareResponse = (ctx) =>
+				{
+					ctx.OwinContext.Response.Headers.Append("X-Frame-Options", "DENY");
+				};
+
 				app.UseFileServer(options);
 			}
 			catch (DirectoryNotFoundException)


### PR DESCRIPTION
Bitte erst Branch `feature/xFrameOptionsManagementWeb` mergen, dann den hier auf Develop rebasen.

Fügt für alle ausgelieferten HTML-Seiten den X-XSS-Protection Header ein.