### PR TITLE
Require old password for user update

### DIFF
--- a/Thinktecture.Relay.ManagementWeb/app/links/links.html
+++ b/Thinktecture.Relay.ManagementWeb/app/links/links.html
@@ -17,7 +17,7 @@
     </div>
 </div>
 
-<div ui-grid="gridOptions" external-scopes="externalScope" class="default-grid"></div>
+<div ui-grid="gridOptions" class="default-grid"></div>
 
 <div class="row row-pagination">
      <div class="col-md-12">

--- a/Thinktecture.Relay.ManagementWeb/app/users/createUserModal.html
+++ b/Thinktecture.Relay.ManagementWeb/app/users/createUserModal.html
@@ -5,7 +5,7 @@
         <h3 class="modal-title" translate ng-if="isEditMode">USERS.MODAL_EDIT_PASSWORD.TITLE</h3>
     </div>
     <div class="modal-body">
-        <p ng-if="isEditMode">{{ 'USERS.MODAL_EDIT_PASSWORD.DESCRIPTION' | translate:user }}</p>
+        <p ng-if="isEditMode" translate="USERS.MODAL_EDIT_PASSWORD.DESCRIPTION" translate-values="{ userName: user.userName}"></p>
         <div class="form-group" ng-class="{'has-error':(createUserForm.username.$invalid && createUserForm.username.$dirty) || userNameUnavailable, 'has-success': userNameAvailable}" ng-if="!isEditMode">
             <label for="username" class="col-sm-2 control-label" translate>COMMON.USERNAME</label>
             <div class="col-sm-10">
@@ -41,7 +41,8 @@
         </div>
     </div>
     <div class="modal-footer">
-        <button type="submit" class="btn btn-primary" ng-disabled="createUserForm.$invalid || userNameUnavailable || passwordsDoNotMatch" translate>COMMON.CREATE</button>
+        <button ng-if="!isEditMode" type="submit" class="btn btn-primary" ng-disabled="createUserForm.$invalid || userNameUnavailable || passwordsDoNotMatch" translate>COMMON.CREATE</button>
+        <button ng-if="isEditMode" type="submit" class="btn btn-primary" ng-disabled="createUserForm.$invalid || userNameUnavailable || passwordsDoNotMatch" translate>COMMON.UPDATE</button>
         <button class="btn btn-default" ng-click="cancel()" translate>COMMON.CANCEL</button>
     </div>
 </form>

--- a/Thinktecture.Relay.ManagementWeb/app/users/createUserModal.html
+++ b/Thinktecture.Relay.ManagementWeb/app/users/createUserModal.html
@@ -15,6 +15,15 @@
                 <span class="text-danger" ng-show="createUserForm.username.$error.required && createUserForm.username.$dirty" translate>COMMON.ERRORS.FIELD_REQUIRED</span>
             </div>
         </div>
+
+        <div ng-if="isEditMode" class="form-group" ng-class="{'has-error':createUserForm.passwordOld.$error.required && createUserForm.passwordOld.$dirty}">
+            <label for="passwordOld" class="col-sm-2 control-label" translate>COMMON.PASSWORD_OLD</label>
+            <div class="col-sm-10">
+                <input type="password" id="passwordOld" name="passwordOld" class="form-control" ng-model="user.passwordOld" placeholder="{{ 'COMMON.PASSWORD_OLD' | translate }}" required />
+                <span class="text-danger" ng-show="createUserForm.password.$error.required && createUserForm.password.$dirty" translate>COMMON.ERRORS.FIELD_REQUIRED</span>
+            </div>
+        </div>
+
         <div class="form-group" ng-class="{'has-error':createUserForm.password.$error.required && createUserForm.password.$dirty}">
             <label for="password" class="col-sm-2 control-label" translate>COMMON.PASSWORD</label>
             <div class="col-sm-10">

--- a/Thinktecture.Relay.ManagementWeb/app/users/deleteUserModal.html
+++ b/Thinktecture.Relay.ManagementWeb/app/users/deleteUserModal.html
@@ -2,9 +2,7 @@
     <button type="button" class="close" ng-click="cancel()" tabindex="-1"><span>&times;</span><span class="sr-only" translate>COMMON.CLOSE</span></button>
     <h3 class="modal-title" translate>USERS.MODAL_DELETE.TITLE</h3>
 </div>
-<div class="modal-body">
-    {{ 'USERS.MODAL_DELETE.DESCRIPTION' | translate:user }}
-</div>
+<div class="modal-body" translate="USERS.MODAL_DELETE.DESCRIPTION" translate-values="{ userName: user.userName }"></div>
 <div class="modal-footer">
     <button class="btn btn-danger" ng-click="submit()" translate>COMMON.DELETE</button>
     <button class="btn btn-default" ng-click="cancel()" translate>COMMON.CANCEL</button>

--- a/Thinktecture.Relay.ManagementWeb/app/users/userOptionsCellTemplate.html
+++ b/Thinktecture.Relay.ManagementWeb/app/users/userOptionsCellTemplate.html
@@ -1,2 +1,2 @@
-<button class="btn btn-sm btn-default" ng-click="getExternalScopes().editPasswordForUser(row.entity)"><span class="fa fa-pencil"></span> Edit Password</button>
-<button class="btn btn-sm btn-default" ng-click="getExternalScopes().deleteUser(row.entity)"><span class="fa fa-trash-o"></span> Delete</button>
+<button class="btn btn-sm btn-default" ng-click="grid.appScope.editPasswordForUser(row.entity)"><span class="fa fa-pencil"></span> Edit Password</button>
+<button class="btn btn-sm btn-default" ng-click="grid.appScope.deleteUser(row.entity)"><span class="fa fa-trash-o"></span> Delete</button>

--- a/Thinktecture.Relay.ManagementWeb/app/users/users.html
+++ b/Thinktecture.Relay.ManagementWeb/app/users/users.html
@@ -8,4 +8,4 @@
     </div>
 </div>
 
-<div ui-grid="gridOptions" external-scopes="externalScope" class="default-grid"></div>
+<div ui-grid="gridOptions" class="default-grid"></div>

--- a/Thinktecture.Relay.ManagementWeb/app/users/users.js
+++ b/Thinktecture.Relay.ManagementWeb/app/users/users.js
@@ -70,7 +70,7 @@
                 });
         };
 
-        function deleteUser (userToDelete) {
+        $scope.deleteUser = function (userToDelete) {
             var modal = $uibModal.open({
                 templateUrl: 'app/users/deleteUserModal.html',
                 controller: 'deleteUserModalController',
@@ -97,9 +97,9 @@
                             });
                     }
                 });
-        }
+        };
 
-        function editPasswordForUser (userToEdit) {
+         $scope.editPasswordForUser = function(userToEdit) {
             var modal = $uibModal.open({
                 templateUrl: 'app/users/createUserModal.html',
                 controller: 'createUserModalController',
@@ -126,15 +126,6 @@
                             });
                     }
                 });
-        }
-
-        $scope.externalScope = {
-            deleteUser: function (user) {
-                deleteUser(user);
-            },
-            editPasswordForUser: function (user) {
-                editPasswordForUser(user);
-            }
         };
     }
 

--- a/Thinktecture.Relay.ManagementWeb/app/users/users.js
+++ b/Thinktecture.Relay.ManagementWeb/app/users/users.js
@@ -122,9 +122,15 @@
                     reloadUsers();
                 }, function (error) {
                     if (error !== 'cancel' && error !== 'backdrop click' && error !== 'escape key press') {
+
+                        var details = '';
+                        if (error.data && error.data.message) {
+                            details = '\r\n' + error.data.message;
+                        }
+
                         $translate('USERS.NOTIFICATIONS.EDIT_PASSWORD_ERROR')
                             .then(function (text) {
-                                notificationService.error(text);
+                                notificationService.error(text + details);
                             });
                     }
                 });

--- a/Thinktecture.Relay.ManagementWeb/app/users/users.js
+++ b/Thinktecture.Relay.ManagementWeb/app/users/users.js
@@ -71,17 +71,18 @@
         };
 
         $scope.deleteUser = function (userToDelete) {
+            var userCopy = JSON.parse(JSON.stringify(userToDelete));
             var modal = $uibModal.open({
                 templateUrl: 'app/users/deleteUserModal.html',
                 controller: 'deleteUserModalController',
                 resolve: {
-                    affectedUser: function () { return userToDelete; }
+                    affectedUser: function () { return userCopy; }
                 }
             });
 
             modal.result
                 .then(function () {
-                    return user.delete(userToDelete.id);
+                    return user.delete(userCopy.id);
                 })
                 .then(function () {
                     $translate('USERS.NOTIFICATIONS.DELETE_SUCCESS')
@@ -100,11 +101,12 @@
         };
 
          $scope.editPasswordForUser = function(userToEdit) {
+            var userCopy = JSON.parse(JSON.stringify(userToEdit));
             var modal = $uibModal.open({
                 templateUrl: 'app/users/createUserModal.html',
                 controller: 'createUserModalController',
                 resolve: {
-                    affectedUser: function () { return userToEdit; }
+                    affectedUser: function () { return userCopy; }
                 }
             });
 

--- a/Thinktecture.Relay.ManagementWeb/appTranslations/translations-en.js
+++ b/Thinktecture.Relay.ManagementWeb/appTranslations/translations-en.js
@@ -4,6 +4,7 @@
     app.module.constant('translationsEn', {
         "COMMON": {
             "CREATE": "Create",
+            "UPDATE": "Update",
             "CLOSE": "Close",
             "CANCEL": "Cancel",
             "USERNAME": "Username",

--- a/Thinktecture.Relay.ManagementWeb/appTranslations/translations-en.js
+++ b/Thinktecture.Relay.ManagementWeb/appTranslations/translations-en.js
@@ -8,6 +8,7 @@
             "CANCEL": "Cancel",
             "USERNAME": "Username",
             "PASSWORD": "Password",
+            "PASSWORD_OLD": "Current password",
             "DELETE": "Delete",
             "EDIT": "Edit",
             "DATE": "Date",

--- a/Thinktecture.Relay.Server/Controller/ManagementWeb/UserController.cs
+++ b/Thinktecture.Relay.Server/Controller/ManagementWeb/UserController.cs
@@ -93,6 +93,18 @@ namespace Thinktecture.Relay.Server.Controller.ManagementWeb
 				return BadRequest();
 			}
 
+			// OldPassword needs to be correct
+			if (_userRepository.Authenticate(user.UserName, user.PasswordOld) == null)
+			{
+				return BadRequest("Old password not okay");
+			}
+
+			// new password and repetition need to match
+			if (user.Password != user.Password2)
+			{
+				return BadRequest("New password and verification do not match");
+			}
+
 			var result = _userRepository.Update(user.Id, user.Password);
 
 			return result ? (IHttpActionResult)Ok() : BadRequest();

--- a/Thinktecture.Relay.Server/Controller/ManagementWeb/UserController.cs
+++ b/Thinktecture.Relay.Server/Controller/ManagementWeb/UserController.cs
@@ -50,6 +50,12 @@ namespace Thinktecture.Relay.Server.Controller.ManagementWeb
 				return BadRequest();
 			}
 
+			// new password and repetition need to match
+			if (user.Password != user.Password2)
+			{
+				return BadRequest("New password and verification do not match");
+			}
+
 			var id = _userRepository.Create(user.UserName, user.Password);
 
 			if (id == Guid.Empty)

--- a/Thinktecture.Relay.Server/Dto/CreateUser.cs
+++ b/Thinktecture.Relay.Server/Dto/CreateUser.cs
@@ -4,5 +4,6 @@ namespace Thinktecture.Relay.Server.Dto
 	{
 		public string UserName { get; set; }
 		public string Password { get; set; }
+		public string Password2 { get; set; }
 	}
 }

--- a/Thinktecture.Relay.Server/Dto/UpdateUser.cs
+++ b/Thinktecture.Relay.Server/Dto/UpdateUser.cs
@@ -5,7 +5,6 @@ namespace Thinktecture.Relay.Server.Dto
 	public class UpdateUser : CreateUser
 	{
 		public Guid Id { get; set; }
-		public string Password2 { get; set; }
 		public string PasswordOld { get; set; }
 	}
 }

--- a/Thinktecture.Relay.Server/Dto/UpdateUser.cs
+++ b/Thinktecture.Relay.Server/Dto/UpdateUser.cs
@@ -5,5 +5,7 @@ namespace Thinktecture.Relay.Server.Dto
 	public class UpdateUser : CreateUser
 	{
 		public Guid Id { get; set; }
+		public string Password2 { get; set; }
+		public string PasswordOld { get; set; }
 	}
 }


### PR DESCRIPTION
Please merge branches
* `feature/unittests`
* `feature/packageUpdates`
* `feature/logging` 
* `feature/accessTokenLifetime` 
* `feature/cacheHeader` 
* `feature/HstsHeader` and
* `feature/errorDetails` first.

Then rebase this onto develop.

This fixes the delete & update user UI bugs (buttons do work now).
The old password is now required in order to change a users current password.
Server does now validate the old password and double-checks if password and password verification are the same.
UI shows corresponding error message as well as general small overhaul of displayed translations / texts regarding the user management.

