### PR TITLE
Increase StreamContent buffer size

### DIFF
--- a/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseWebTargetRequestMessageBuilder.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseWebTargetRequestMessageBuilder.cs
@@ -134,7 +134,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 			if (request.Stream != Stream.Null)
 			{
 				_logger?.Verbose("Adding request stream to request. request-id={RequestId}", request.RequestId);
-				message.Content = new StreamContent(request.Stream);
+				message.Content = new StreamContent(request.Stream, 0x10000);
 			}
 
 			if (request.AcknowledgmentMode == AcknowledgmentMode.Manual)

--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnection.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnection.cs
@@ -467,7 +467,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 
 		private async Task PostResponseAsync(RequestContext ctx, IOnPremiseTargetResponse response, CancellationToken cancellationToken)
 		{
-			await PostToRelay("/forward", headers => headers.Add("X-TTRELAY-METADATA", JsonConvert.SerializeObject(response)), new StreamContent(response.Stream ?? Stream.Null), cancellationToken).ConfigureAwait(false);
+			await PostToRelay("/forward", headers => headers.Add("X-TTRELAY-METADATA", JsonConvert.SerializeObject(response)), new StreamContent(response.Stream ?? Stream.Null, 0x10000), cancellationToken).ConfigureAwait(false);
 			ctx.IsRelayServerNotified = true;
 		}
 
@@ -520,7 +520,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 			setHeaders?.Invoke(request.Headers);
 			request.Content = content;
 
-			return await _httpClient.SendAsync(request, cancellationToken);
+			return await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
 		}
 
 		private TimeSpan GetRandomWaitTime()

--- a/Thinktecture.Relay.Server/Controller/RequestController.cs
+++ b/Thinktecture.Relay.Server/Controller/RequestController.cs
@@ -36,7 +36,7 @@ namespace Thinktecture.Relay.Server.Controller
 				return NotFound();
 			}
 
-			return new ResponseMessageResult(new HttpResponseMessage() { Content = new StreamContent(stream) });
+			return new ResponseMessageResult(new HttpResponseMessage() { Content = new StreamContent(stream, 0x10000) });
 		}
 
 		[HttpGet]

--- a/Thinktecture.Relay.Server/Http/HttpResponseMessageBuilder.cs
+++ b/Thinktecture.Relay.Server/Http/HttpResponseMessageBuilder.cs
@@ -96,7 +96,7 @@ namespace Thinktecture.Relay.Server.Http
 					throw new InvalidOperationException(); // TODO what now?
 				}
 
-				content = new StreamContent(stream);
+				content = new StreamContent(stream, 0x10000);
 			}
 
 			AddContentHttpHeaders(content, response.HttpHeaders);


### PR DESCRIPTION
The default buffer size of `StreamContent` is 4096 bytes, which, in our case, is too small especially for HTTPS connections. The result was the transport of bigger responses was throttled by around factor 10. The size of `0x10000`(64KB) should be the best choice between memory allocation and file system performance under load.