### PR TITLE
Made OnPremiseConnector compatible with load balancers using session based affinity

### DIFF
--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnection.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnection.cs
@@ -64,7 +64,8 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 			_onPremiseTargetConnectorFactory = onPremiseTargetConnectorFactory;
 			_logger = logger;
 			_connectors = new ConcurrentDictionary<string, IOnPremiseTargetConnector>(StringComparer.OrdinalIgnoreCase);
-			_httpClient = new HttpClient()
+			CookieContainer = new CookieContainer();
+			_httpClient = new HttpClient(new HttpClientHandler() { CookieContainer = CookieContainer, UseCookies = true})
 			{
 				Timeout = requestTimeout,
 			};


### PR DESCRIPTION
Load balancers like Amazon Elastic and Application Load Balancers use a session cookie for affinity.