### PR TITLE
add an option to configure a delay before reconnect to relayserver

### DIFF
--- a/Thinktecture.Relay.OnPremiseConnector/RelayServerConnector.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/RelayServerConnector.cs
@@ -49,10 +49,12 @@ namespace Thinktecture.Relay.OnPremiseConnector
 		/// <param name="relayServer">An <see cref="Uri"/> containing the RelayServer's base url.</param>
 		/// <param name="requestTimeoutInSeconds">An <see cref="Int32"/> defining the timeout in seconds.</param>
 		/// <param name="tokenRefreshWindowInSeconds">An <see cref="Int32"/> defining the access token refresh window in seconds.</param>
-		public RelayServerConnector(Assembly versionAssembly, string userName, string password, Uri relayServer, int requestTimeoutInSeconds = 30, int tokenRefreshWindowInSeconds = 5)
+		/// <param name="minConnectWaitTime"> An <see cref="Int32"/> defining the min waitingtime before reconnect is forced </param>
+		/// <param name="maxConnectWaitTime"> An <see cref="Int32"/> defining the max waitingtime before reconnect is forced </param>
+		public RelayServerConnector(Assembly versionAssembly, string userName, string password, Uri relayServer, int requestTimeoutInSeconds = 30, int tokenRefreshWindowInSeconds = 5, int minConnectWaitTime = 5, int maxConnectWaitTime = 30)
 		{
 			var factory = _container.Resolve<IRelayServerConnectionFactory>();
-			_connection = factory.Create(versionAssembly, userName, password, relayServer, TimeSpan.FromSeconds(requestTimeoutInSeconds), TimeSpan.FromSeconds(tokenRefreshWindowInSeconds));
+			_connection = factory.Create(new RelayServerConnectionConfig(versionAssembly,userName,password,relayServer, TimeSpan.FromSeconds(requestTimeoutInSeconds), TimeSpan.FromSeconds(tokenRefreshWindowInSeconds), minConnectWaitTime, maxConnectWaitTime));
 		}
 
 		/// <summary>

--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/IRelayServerConnectionFactory.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/IRelayServerConnectionFactory.cs
@@ -1,10 +1,7 @@
-using System;
-using System.Reflection;
-
 namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 {
 	internal interface IRelayServerConnectionFactory
 	{
-		IRelayServerConnection Create(Assembly versionAssembly, string userName, string password, Uri relayServer, TimeSpan requestTimeout, TimeSpan tokenRefreshWindow);
+		IRelayServerConnection Create(RelayServerConnectionConfig config);
 	}
 }

--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnectionConfig.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnectionConfig.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Reflection;
+using Serilog;
+using Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget;
+
+namespace Thinktecture.Relay.OnPremiseConnector.SignalR
+{
+	public class RelayServerConnectionConfig
+	{
+		public RelayServerConnectionConfig(Assembly versionAssembly, String userName, String password, Uri relayServerUri, TimeSpan requestTimeout, TimeSpan tokenRefreshWindow, Int32 minConnectWaitTimeInSeconds, Int32 maxConnectWaitTimeInSeconds)
+		{
+			VersionAssembly = versionAssembly;
+			UserName = userName;
+			Password = password;
+			RelayServerUri = relayServerUri;
+			RequestTimeout = requestTimeout;
+			TokenRefreshWindow = tokenRefreshWindow;
+			MinConnectWaitTimeInSeconds = minConnectWaitTimeInSeconds;
+			MaxConnectWaitTimeInSeconds = maxConnectWaitTimeInSeconds;
+		}
+
+		public Assembly VersionAssembly { get; private set; }
+		public String UserName { get; private set; }
+		public String Password { get; private set; }
+		public Uri RelayServerUri { get; private set; }
+		public TimeSpan RequestTimeout { get; private set; }
+		public TimeSpan TokenRefreshWindow { get; private set; }
+		public int MinConnectWaitTimeInSeconds;
+		public int MaxConnectWaitTimeInSeconds;
+	}
+}

--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnectionFactory.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnectionFactory.cs
@@ -18,10 +18,11 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 			_onPremiseTargetConnectorFactory = onPremiseTargetConnectorFactory ?? throw new ArgumentNullException(nameof(onPremiseTargetConnectorFactory));
 		}
 
-		public IRelayServerConnection Create(Assembly versionAssembly, string userName, string password, Uri relayServer, TimeSpan requestTimeout, TimeSpan tokenRefreshWindow)
+		public IRelayServerConnection Create(RelayServerConnectionConfig config)
 		{
-			_logger?.Information("Creating new connection for RelayServer {RelayServerUrl} and link user {UserName}", relayServer, userName);
-			var connection = new RelayServerConnection(versionAssembly, userName, password, relayServer, requestTimeout, tokenRefreshWindow, _onPremiseTargetConnectorFactory, _logger);
+			_logger?.Information("Creating new connection for RelayServer {RelayServerUrl} and link user {UserName}", config.RelayServerUri, config.UserName);
+			var connection = new RelayServerConnection(config, _onPremiseTargetConnectorFactory, _logger);
+			
 
 			// registering connection with maintenance loop
 			_maintenanceLoop.RegisterConnection(connection);


### PR DESCRIPTION
Our provider banned connection to our relayserver, because our multiple reconnects from the OnPremisesBackend-Services looked like a ddos-attack. 
So we decided to implement an optional delay which the backend controls (e.g in the app.config).