### PR TITLE
Bugfix: Loading did fail when only one interface was implemented

### DIFF
--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/MaintenanceLoop.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/MaintenanceLoop.cs
@@ -27,7 +27,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 			_checkInterval = TimeSpan.FromSeconds(1);
 			_cancellationTokenSource = new CancellationTokenSource();
 			_connections = new List<IRelayServerConnection>();
-			_connectionsForLoop = new IRelayServerConnection[0];
+			_connectionsForLoop = Array.Empty<IRelayServerConnection>();
 		}
 
 		public void RegisterConnection(IRelayServerConnection connection)

--- a/Thinktecture.Relay.Server.Test/Diagnostics/TraceFileReaderTest.cs
+++ b/Thinktecture.Relay.Server.Test/Diagnostics/TraceFileReaderTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -32,7 +33,7 @@ namespace Thinktecture.Relay.Server.Diagnostics
 		[TestMethod]
 		public void Can_read_empty_content_file()
 		{
-			File.WriteAllBytes("test.content.txt", new byte[0]);
+			File.WriteAllBytes("test.content.txt", Array.Empty<byte>());
 
 			var sut = new TraceFileReader();
 			var result = sut.ReadContentFileAsync("test.content.txt").Result;

--- a/Thinktecture.Relay.Server/DependencyInjection/CustomCodeAssemblyLoader.cs
+++ b/Thinktecture.Relay.Server/DependencyInjection/CustomCodeAssemblyLoader.cs
@@ -84,7 +84,7 @@ namespace Thinktecture.Relay.Server.DependencyInjection
 		public Type GetType(Type type)
 		{
 			var types = GetTypes(type);
-			if (types == null)
+			if (types.Length == 0)
 				return null;
 
 			if (types.Length > 1)
@@ -100,7 +100,7 @@ namespace Thinktecture.Relay.Server.DependencyInjection
 		{
 			var assembly = Assembly;
 			if (assembly == null)
-				return null;
+				return new Type[0];
 
 			var types = GetTypes(assembly, type);
 			if (types.Length == 0)

--- a/Thinktecture.Relay.Server/DependencyInjection/CustomCodeAssemblyLoader.cs
+++ b/Thinktecture.Relay.Server/DependencyInjection/CustomCodeAssemblyLoader.cs
@@ -100,7 +100,7 @@ namespace Thinktecture.Relay.Server.DependencyInjection
 		{
 			var assembly = Assembly;
 			if (assembly == null)
-				return new Type[0];
+				return Array.Empty<Type>();
 
 			var types = GetTypes(assembly, type);
 			if (types.Length == 0)

--- a/Thinktecture.Relay.Server/Diagnostics/TraceFileWriter.cs
+++ b/Thinktecture.Relay.Server/Diagnostics/TraceFileWriter.cs
@@ -18,7 +18,7 @@ namespace Thinktecture.Relay.Server.Diagnostics
 		public Task WriteContentFileAsync(string fileName, byte[] content)
 		{
 			if (content == null)
-				content = new byte[0];
+				content = Array.Empty<byte>();
 
 			return WriteAsync(fileName, content);
 		}

--- a/Thinktecture.Relay.Server/Diagnostics/TraceTransformation.cs
+++ b/Thinktecture.Relay.Server/Diagnostics/TraceTransformation.cs
@@ -31,7 +31,7 @@ namespace Thinktecture.Relay.Server.Diagnostics
 		{
 			if (traceFile.Content == null)
 			{
-				return new byte[0];
+				return Array.Empty<byte>();
 			}
 
 			var contentEncoding = traceFile.Headers.ContainsKey("content-encoding") ? traceFile.Headers["content-encoding"] : String.Empty;

--- a/Thinktecture.Relay.Server/Http/HttpResponseMessageBuilder.cs
+++ b/Thinktecture.Relay.Server/Http/HttpResponseMessageBuilder.cs
@@ -44,7 +44,7 @@ namespace Thinktecture.Relay.Server.Http
 				_logger?.Verbose("Received no response. request-id={RequestId}", requestId);
 
 				message.StatusCode = HttpStatusCode.GatewayTimeout;
-				message.Content = new ByteArrayContent(new byte[0]);
+				message.Content = new ByteArrayContent(Array.Empty<byte>());
 				message.Content.Headers.Add("X-TTRELAY-TIMEOUT", "On-Premise");
 			}
 			else
@@ -77,7 +77,7 @@ namespace Thinktecture.Relay.Server.Http
 			{
 				_logger?.Verbose("Received empty body. request-id={RequestId}", response.RequestId);
 
-				content = new ByteArrayContent(new byte[0]);
+				content = new ByteArrayContent(Array.Empty<byte>());
 			}
 			else if (response.Body != null)
 			{

--- a/Thinktecture.Relay.Server/Http/OnPremiseRequestBuilder.cs
+++ b/Thinktecture.Relay.Server/Http/OnPremiseRequestBuilder.cs
@@ -64,7 +64,7 @@ namespace Thinktecture.Relay.Server.Http
 					else
 					{
 						// a length of 0 indicates that there is a larger body available on the server
-						request.Body = new byte[0];
+						request.Body = Array.Empty<byte>();
 					}
 
 					request.ContentLength = storeStream.Length;

--- a/Thinktecture.Relay.Server/SignalR/InMemoryPostDataTemporaryStore.cs
+++ b/Thinktecture.Relay.Server/SignalR/InMemoryPostDataTemporaryStore.cs
@@ -11,7 +11,7 @@ namespace Thinktecture.Relay.Server.SignalR
 	internal class InMemoryPostDataTemporaryStore : IPostDataTemporaryStore, IDisposable
 	{
 		private static readonly TimeSpan _cleanupInterval = TimeSpan.FromMinutes(1);
-		private static readonly byte[] _emptyByteArray = new byte[0];
+		private static readonly byte[] _emptyByteArray = Array.Empty<byte>();
 
 		private readonly ILogger _logger;
 		private readonly TimeSpan _storagePeriod;


### PR DESCRIPTION
Would run into issues with the following `.Single()` call, when there is no plugin found for an interface, resulting in not loading any plugins of only one interface is implemented and not both.