### PR TITLE
Get HttpClient via factory

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,10 @@ insert_final_newline = true
 
 csharp_space_after_keywords_in_control_flow_statements = true
 csharp_space_after_cast = false
+
+[*.config]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = crlf
+insert_final_newline = true

--- a/Thinktecture.Relay.OnPremiseConnector/Net/Http/HttpClientFactory.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/Net/Http/HttpClientFactory.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Net.Http;
+
+namespace Thinktecture.Relay.OnPremiseConnector.Net.Http
+{
+	public class HttpClientFactory : IHttpClientFactory
+	{
+		public HttpClient CreateClient(String name)
+		{
+			// We ignore the name here, as this should be as simple as it gets.
+			return new HttpClient();
+		}
+	}
+}

--- a/Thinktecture.Relay.OnPremiseConnector/Net/Http/IHttpClientFactory.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/Net/Http/IHttpClientFactory.cs
@@ -1,0 +1,9 @@
+using System.Net.Http;
+
+namespace Thinktecture.Relay.OnPremiseConnector.Net.Http
+{
+	public interface IHttpClientFactory
+	{
+		HttpClient CreateClient(string name);
+	}
+}

--- a/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/IOnPremiseWebTargetRequestMessageBuilder.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/IOnPremiseWebTargetRequestMessageBuilder.cs
@@ -5,6 +5,6 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 {
 	internal interface IOnPremiseWebTargetRequestMessageBuilder
 	{
-		HttpRequestMessage CreateLocalTargetRequestMessage(Uri baseUri, string url, IOnPremiseTargetRequest request, string relayedRequestHeader);
+		HttpRequestMessage CreateLocalTargetRequestMessage(Uri baseUri, string url, IOnPremiseTargetRequest request, string relayedRequestHeader, TimeSpan requestTimeout);
 	}
 }

--- a/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/IOnPremiseWebTargetRequestMessageBuilder.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/IOnPremiseWebTargetRequestMessageBuilder.cs
@@ -5,6 +5,6 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 {
 	internal interface IOnPremiseWebTargetRequestMessageBuilder
 	{
-		HttpRequestMessage CreateLocalTargetRequestMessage(Uri baseUri, string url, IOnPremiseTargetRequest request, string relayedRequestHeader, TimeSpan requestTimeout);
+		HttpRequestMessage CreateLocalTargetRequestMessage(Uri baseUri, string url, IOnPremiseTargetRequest request, string relayedRequestHeader);
 	}
 }

--- a/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseTargetConnectorFactory.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseTargetConnectorFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using Serilog;
+using Thinktecture.Relay.OnPremiseConnector.Net.Http;
 
 namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 {
@@ -7,16 +8,18 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 	{
 		private readonly ILogger _logger;
 		private readonly Func<IOnPremiseWebTargetRequestMessageBuilder> _requestMessageBuilderFactory;
+		private readonly IHttpClientFactory _httpClientFactory;
 
-		public OnPremiseTargetConnectorFactory(ILogger logger, Func<IOnPremiseWebTargetRequestMessageBuilder> requestMessageBuilderFactory)
+		public OnPremiseTargetConnectorFactory(ILogger logger, Func<IOnPremiseWebTargetRequestMessageBuilder> requestMessageBuilderFactory, IHttpClientFactory httpClientFactory)
 		{
 			_logger = logger;
 			_requestMessageBuilderFactory = requestMessageBuilderFactory ?? throw new ArgumentNullException(nameof(requestMessageBuilderFactory));
+			_httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
 		}
 
 		public IOnPremiseTargetConnector Create(Uri baseUri, TimeSpan requestTimeout)
 		{
-			return new OnPremiseWebTargetConnector(baseUri, requestTimeout, _logger, _requestMessageBuilderFactory());
+			return new OnPremiseWebTargetConnector(baseUri, requestTimeout, _logger, _requestMessageBuilderFactory(), _httpClientFactory);
 		}
 
 		public IOnPremiseTargetConnector Create(Type handlerType, TimeSpan requestTimeout)

--- a/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseWebTargetConnector.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseWebTargetConnector.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Serilog;
+using Thinktecture.Relay.OnPremiseConnector.Net.Http;
 
 namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 {
@@ -15,7 +16,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 		private readonly Uri _baseUri;
 		private readonly HttpClient _httpClient;
 
-		public OnPremiseWebTargetConnector(Uri baseUri, TimeSpan requestTimeout, ILogger logger, IOnPremiseWebTargetRequestMessageBuilder requestMessageBuilder)
+		public OnPremiseWebTargetConnector(Uri baseUri, TimeSpan requestTimeout, ILogger logger, IOnPremiseWebTargetRequestMessageBuilder requestMessageBuilder, IHttpClientFactory httpClientFactory)
 		{
 			if (requestTimeout < TimeSpan.Zero)
 				throw new ArgumentOutOfRangeException(nameof(requestTimeout), "Request timeout cannot be negative.");
@@ -24,7 +25,8 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 			_logger = logger;
 			_requestMessageBuilder = requestMessageBuilder ?? throw new ArgumentNullException(nameof(requestMessageBuilder));
 
-			_httpClient = new HttpClient() { Timeout = requestTimeout };
+			_httpClient = httpClientFactory.CreateClient("WebTarget");
+			_httpClient.Timeout = requestTimeout;
 		}
 
 		public async Task<IOnPremiseTargetResponse> GetResponseFromLocalTargetAsync(string url, IOnPremiseTargetRequest request, string relayedRequestHeader)

--- a/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseWebTargetConnector.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseWebTargetConnector.cs
@@ -14,6 +14,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 		private readonly ILogger _logger;
 		private readonly IOnPremiseWebTargetRequestMessageBuilder _requestMessageBuilder;
 		private readonly Uri _baseUri;
+		private readonly TimeSpan _requestTimeout;
 		private readonly HttpClient _httpClient;
 
 		public OnPremiseWebTargetConnector(Uri baseUri, TimeSpan requestTimeout, ILogger logger, IOnPremiseWebTargetRequestMessageBuilder requestMessageBuilder, IHttpClientFactory httpClientFactory)
@@ -22,11 +23,11 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 				throw new ArgumentOutOfRangeException(nameof(requestTimeout), "Request timeout cannot be negative.");
 
 			_baseUri = baseUri ?? throw new ArgumentNullException(nameof(baseUri));
+			_requestTimeout = requestTimeout;
 			_logger = logger;
 			_requestMessageBuilder = requestMessageBuilder ?? throw new ArgumentNullException(nameof(requestMessageBuilder));
 
 			_httpClient = httpClientFactory.CreateClient("WebTarget");
-			_httpClient.Timeout = requestTimeout;
 		}
 
 		public async Task<IOnPremiseTargetResponse> GetResponseFromLocalTargetAsync(string url, IOnPremiseTargetRequest request, string relayedRequestHeader)
@@ -47,7 +48,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 
 			try
 			{
-				var requestMessage = _requestMessageBuilder.CreateLocalTargetRequestMessage(_baseUri, url, request, relayedRequestHeader);
+				var requestMessage = _requestMessageBuilder.CreateLocalTargetRequestMessage(_baseUri, url, request, relayedRequestHeader, _requestTimeout);
 				var message = await _httpClient.SendAsync(requestMessage).ConfigureAwait(false);
 
 				response.StatusCode = message.StatusCode;

--- a/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseWebTargetRequestMessageBuilder.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseWebTargetRequestMessageBuilder.cs
@@ -126,12 +126,11 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 			_logger = logger;
 		}
 
-		public HttpRequestMessage CreateLocalTargetRequestMessage(Uri baseUri, string url, IOnPremiseTargetRequest request, string relayedRequestHeader, TimeSpan requestTimeout)
+		public HttpRequestMessage CreateLocalTargetRequestMessage(Uri baseUri, string url, IOnPremiseTargetRequest request, string relayedRequestHeader)
 		{
 			_logger?.Verbose("Creating web request for request-id={RequestId}", request.RequestId);
 
 			var message = new HttpRequestMessage(new HttpMethod(request.HttpMethod), String.IsNullOrWhiteSpace(url) ? baseUri : new Uri(baseUri, url));
-			message.Properties["RequestTimeout"] = requestTimeout;
 
 			if (request.Stream != Stream.Null)
 			{

--- a/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseWebTargetRequestMessageBuilder.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/OnPremiseTarget/OnPremiseWebTargetRequestMessageBuilder.cs
@@ -126,11 +126,13 @@ namespace Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget
 			_logger = logger;
 		}
 
-		public HttpRequestMessage CreateLocalTargetRequestMessage(Uri baseUri, string url, IOnPremiseTargetRequest request, string relayedRequestHeader)
+		public HttpRequestMessage CreateLocalTargetRequestMessage(Uri baseUri, string url, IOnPremiseTargetRequest request, string relayedRequestHeader, TimeSpan requestTimeout)
 		{
 			_logger?.Verbose("Creating web request for request-id={RequestId}", request.RequestId);
 
 			var message = new HttpRequestMessage(new HttpMethod(request.HttpMethod), String.IsNullOrWhiteSpace(url) ? baseUri : new Uri(baseUri, url));
+			message.Properties["RequestTimeout"] = requestTimeout;
+
 			if (request.Stream != Stream.Null)
 			{
 				_logger?.Verbose("Adding request stream to request. request-id={RequestId}", request.RequestId);

--- a/Thinktecture.Relay.OnPremiseConnector/RelayServerConnector.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/RelayServerConnector.cs
@@ -23,6 +23,7 @@ namespace Thinktecture.Relay.OnPremiseConnector
 			builder.RegisterLogger();
 			builder.RegisterType<OnPremiseWebTargetRequestMessageBuilder>().As<IOnPremiseWebTargetRequestMessageBuilder>();
 			builder.RegisterType<RelayServerConnectionFactory>().As<IRelayServerConnectionFactory>();
+			builder.RegisterType<HttpClientFactory>().As<IHttpClientFactory>().SingleInstance();
 			builder.RegisterType<OnPremiseTargetConnectorFactory>().As<IOnPremiseTargetConnectorFactory>();
 			builder.RegisterType<HeartbeatChecker>().As<IHeartbeatChecker>();
 			builder.RegisterType<TokenExpiryChecker>().As<ITokenExpiryChecker>();

--- a/Thinktecture.Relay.OnPremiseConnector/ServiceCollectionExtensions.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/ServiceCollectionExtensions.cs
@@ -10,19 +10,19 @@ namespace Thinktecture.Relay.OnPremiseConnector
 		public static IServiceCollection AddOnPremiseConnectorServices(this IServiceCollection collection)
 		{
 			return collection
-				.AddTransient<IOnPremiseWebTargetRequestMessageBuilder, OnPremiseWebTargetRequestMessageBuilder>()
-				.AddTransient<IRelayServerConnectionFactory, RelayServerConnectionFactory>()
-				.AddTransient<IHttpClientFactory, HttpClientFactory>()
-				.AddTransient<IOnPremiseTargetConnectorFactory, OnPremiseTargetConnectorFactory>()
-				.AddTransient<IHeartbeatChecker, HeartbeatChecker>()
-				.AddTransient<ITokenExpiryChecker, TokenExpiryChecker>()
+				.AddSingleton<IOnPremiseWebTargetRequestMessageBuilder, OnPremiseWebTargetRequestMessageBuilder>()
+				.AddSingleton<IHttpClientFactory, HttpClientFactory>()
 				.AddSingleton<MaintenanceLoop>()
 				.AddSingleton<IMaintenanceLoop>(ctx =>
 				{
 					var loop = ctx.GetService<MaintenanceLoop>();
 					loop.StartLoop();
 					return loop;
-				});
+				})
+				.AddTransient<IRelayServerConnectionFactory, RelayServerConnectionFactory>()
+				.AddTransient<IOnPremiseTargetConnectorFactory, OnPremiseTargetConnectorFactory>()
+				.AddTransient<IHeartbeatChecker, HeartbeatChecker>()
+				.AddTransient<ITokenExpiryChecker, TokenExpiryChecker>();
 		}
 
 	}

--- a/Thinktecture.Relay.OnPremiseConnector/ServiceCollectionExtensions.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/ServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.DependencyInjection;
+using Thinktecture.Relay.OnPremiseConnector.Net.Http;
+using Thinktecture.Relay.OnPremiseConnector.OnPremiseTarget;
+using Thinktecture.Relay.OnPremiseConnector.SignalR;
+
+namespace Thinktecture.Relay.OnPremiseConnector
+{
+	public static class ServiceCollectionExtensions
+	{
+		public static IServiceCollection AddOnPremiseConnectorServices(this IServiceCollection collection)
+		{
+			return collection
+				.AddTransient<IOnPremiseWebTargetRequestMessageBuilder, OnPremiseWebTargetRequestMessageBuilder>()
+				.AddTransient<IRelayServerConnectionFactory, RelayServerConnectionFactory>()
+				.AddTransient<IHttpClientFactory, HttpClientFactory>()
+				.AddTransient<IOnPremiseTargetConnectorFactory, OnPremiseTargetConnectorFactory>()
+				.AddTransient<IHeartbeatChecker, HeartbeatChecker>()
+				.AddTransient<ITokenExpiryChecker, TokenExpiryChecker>()
+				.AddSingleton<MaintenanceLoop>()
+				.AddSingleton<IMaintenanceLoop>(ctx =>
+				{
+					var loop = ctx.GetService<MaintenanceLoop>();
+					loop.StartLoop();
+					return loop;
+				});
+		}
+
+	}
+}

--- a/Thinktecture.Relay.OnPremiseConnector/Thinktecture.Relay.OnPremiseConnector.csproj
+++ b/Thinktecture.Relay.OnPremiseConnector/Thinktecture.Relay.OnPremiseConnector.csproj
@@ -6,8 +6,11 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.2" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.0" />
     <PackageReference Include="AutofacSerilogIntegration" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.2.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.1" />
     <PackageReference Include="Serilog" Version="2.6.0" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
     <PackageReference Include="System.Net.Security" Version="4.3.0" />

--- a/Thinktecture.Relay.OnPremiseConnector/Thinktecture.Relay.OnPremiseConnector.csproj
+++ b/Thinktecture.Relay.OnPremiseConnector/Thinktecture.Relay.OnPremiseConnector.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.2" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.2" />
     <PackageReference Include="AutofacSerilogIntegration" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.2.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />

--- a/Thinktecture.Relay.OnPremiseConnectorService/App.config
+++ b/Thinktecture.Relay.OnPremiseConnectorService/App.config
@@ -1,70 +1,81 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <configuration>
-  <configSections>
-    <section name="relayServer" type="Thinktecture.Relay.OnPremiseConnectorService.Configuration.RelayServerSection, Thinktecture.Relay.OnPremiseConnectorService" />
-  </configSections>
-  <!--
+	<configSections>
+		<section name="relayServer" type="Thinktecture.Relay.OnPremiseConnectorService.Configuration.RelayServerSection, Thinktecture.Relay.OnPremiseConnectorService" />
+	</configSections>
+	<!--
   <system.net>
     <defaultProxy enabled="true">
       <proxy
          bypassonlocal="False"
          usesystemdefault="True"
       />
-    </defaultProxy> 
+    </defaultProxy>
   </system.net>
   -->
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
-  </startup>
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+	</startup>
 
-  <appSettings>
-    <!-- Logging -->
-    <add key="serilog:minimum-level" value="Debug" />
-    <add key="serilog:using:HttpContextData" value="Serilog.Enrichers.HttpContextData" />
-    <add key="serilog:enrich:WithHttpContextData" />
-    <add key="serilog:enrich:FromLogContext" />
-    <add key="serilog:enrich:with-property:Application" value="OnPremiseConnector Dev" />
-    <add key="serilog:using:Console" value="Serilog.Sinks.Console" />
-    <add key="serilog:write-to:Console" />
-    <add key="serilog:using:Trace" value="Serilog.Sinks.Trace" />
-    <add key="serilog:write-to:Trace" />
-    <add key="serilog:using:Seq" value="Serilog.Sinks.Seq" />
-    <add key="serilog:write-to:Seq.serverUrl" value="http://localhost:5341/" />
-  </appSettings>
+	<appSettings>
+		<!-- Logging -->
+		<add key="serilog:minimum-level" value="Debug" />
+		<add key="serilog:using:HttpContextData" value="Serilog.Enrichers.HttpContextData" />
+		<add key="serilog:enrich:WithHttpContextData" />
+		<add key="serilog:enrich:FromLogContext" />
+		<add key="serilog:enrich:with-property:Application" value="OnPremiseConnector Dev" />
+		<add key="serilog:using:Console" value="Serilog.Sinks.Console" />
+		<add key="serilog:write-to:Console" />
+		<add key="serilog:using:Trace" value="Serilog.Sinks.Trace" />
+		<add key="serilog:write-to:Trace" />
+		<!--
+		<add key="serilog:using:Seq" value="Serilog.Sinks.Seq" />
+		<add key="serilog:write-to:Seq.serverUrl" value="http://localhost:5341/" />
+		-->
+	</appSettings>
 
   <relayServer baseUrl="http://localhost:20000/" ignoreSslErrors="false" timeout="00:00:30" >
     <security authenticationType="Identity" accessTokenRefreshWindow="0.00:01:00">
       <identity userName="test" password="Ydy00/DbyMuGNwFnRDEmRc5Tg4z4wdnLmroSA5rt3z1/iQJYd2ctNhjnDWVPH+vGdzTpbW6BRpiW5GQOPzEka5CyYKgH5HXqgEriSUFjEtNo0eK2syQShFHoRuJnX6F5/iZPoA==" />
     </security>
 
-    <onPremiseTargets>
-      <web key="tt" baseUrl="http://thinktecture.com/" />
-      <web key="lh" baseUrl="http://localhost/" />
-    </onPremiseTargets>
-  </relayServer>
+		<onPremiseTargets>
+			<web key="tt" baseUrl="http://thinktecture.com/" />
+			<web key="lh" baseUrl="http://localhost/" />
+		</onPremiseTargets>
+	</relayServer>
 
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.AspNet.SignalR.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.2" newVersion="4.1.1.2" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+	<runtime>
+		<assemblyBinding>
+			<dependentAssembly>
+				<assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+		<assemblyBinding>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+		<assemblyBinding>
+			<dependentAssembly>
+				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+		<assemblyBinding>
+			<dependentAssembly>
+				<assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+		<assemblyBinding>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.1.2" newVersion="4.1.1.2" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
 </configuration>

--- a/Thinktecture.Relay.OnPremiseConnectorService/Thinktecture.Relay.OnPremiseConnectorService.csproj
+++ b/Thinktecture.Relay.OnPremiseConnectorService/Thinktecture.Relay.OnPremiseConnectorService.csproj
@@ -40,11 +40,19 @@
     <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
     </Reference>
+    <Reference Include="Autofac.Extensions.DependencyInjection, Version=4.2.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da">
+      <HintPath>..\packages\Autofac.Extensions.DependencyInjection.4.2.2\lib\netstandard1.1\Autofac.Extensions.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="AutofacSerilogIntegration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d672c67444a98ac9, processorArchitecture=MSIL">
       <HintPath>..\packages\AutofacSerilogIntegration.2.0.0\lib\net45\AutofacSerilogIntegration.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.SignalR.Client, Version=2.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.SignalR.Client.2.2.2\lib\net45\Microsoft.AspNet.SignalR.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.1\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>

--- a/Thinktecture.Relay.OnPremiseConnectorService/packages.config
+++ b/Thinktecture.Relay.OnPremiseConnectorService/packages.config
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="4.6.2" targetFramework="net46" />
+  <package id="Autofac.Extensions.DependencyInjection" version="4.2.2" targetFramework="net46" />
   <package id="AutofacSerilogIntegration" version="2.0.0" targetFramework="net46" />
   <package id="Microsoft.AspNet.SignalR.Client" version="2.2.2" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.1" targetFramework="net46" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Microsoft.NETCore.Platforms" version="2.0.1" targetFramework="net46" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
@@ -22,6 +24,7 @@
   <package id="Serilog.Sinks.Seq" version="3.4.0" targetFramework="net46" />
   <package id="Serilog.Sinks.Trace" version="2.1.0" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net46" />
   <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net46" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net46" />

--- a/Thinktecture.Relay.sln.DotSettings
+++ b/Thinktecture.Relay.sln.DotSettings
@@ -14,7 +14,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_STYLE/@EntryValue">Tab</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/USE_INDENT_FROM_VS/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/USE_INDENT_FROM_VS/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CssFormatter/ALIGNMENT_TAB_FILL_STYLE/@EntryValue">OPTIMAL_FILL</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/HtmlFormatter/ALIGNMENT_TAB_FILL_STYLE/@EntryValue">OPTIMAL_FILL</s:String>
@@ -23,9 +23,66 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/ResxFormatter/ALIGNMENT_TAB_FILL_STYLE/@EntryValue">OPTIMAL_FILL</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/VBFormat/ALIGNMENT_TAB_FILL_STYLE/@EntryValue">OPTIMAL_FILL</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/ALIGNMENT_TAB_FILL_STYLE/@EntryValue">OPTIMAL_FILL</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/ALIGNMENT_TAB_FILL_STYLE/@EntryValue">OPTIMAL_FILL</s:String>
+	
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/INDENT_SIZE/@EntryValue">2</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/TAB_WIDTH/@EntryValue">2</s:Int64>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/USE_INDENT_FROM_VS/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="AA_BB" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FBLOCK_005FSCOPE_005FCONSTANT/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FBLOCK_005FSCOPE_005FFUNCTION/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FBLOCK_005FSCOPE_005FVARIABLE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FCLASS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FCONSTRUCTOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FFUNCTION/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FGLOBAL_005FVARIABLE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FLABEL/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FLOCAL_005FCONSTRUCTOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FLOCAL_005FVARIABLE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FOBJECT_005FPROPERTY_005FOF_005FFUNCTION/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FPARAMETER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FCLASS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FENUM/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FENUM_005FMEMBER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FINTERFACE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="I" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FMIXED_005FENUM/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FMODULE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FMODULE_005FEXPORTED/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FMODULE_005FLOCAL/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPRIVATE_005FMEMBER_005FACCESSOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPRIVATE_005FSTATIC_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPRIVATE_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPRIVATE_005FTYPE_005FMETHOD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPROTECTED_005FMEMBER_005FACCESSOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPROTECTED_005FSTATIC_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPROTECTED_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPROTECTED_005FTYPE_005FMETHOD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPUBLIC_005FMEMBER_005FACCESSOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPUBLIC_005FSTATIC_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPUBLIC_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPUBLIC_005FTYPE_005FMETHOD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FTYPE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FTYPE_005FPARAMETER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FHTML_005FCONTROL/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FTAG_005FNAME/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FTAG_005FPREFIX/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=NAMESPACE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=AutoRecoverer/@EntryIndexedValue">LIVE_MONITOR</s:String>
+	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=Format/@EntryIndexedValue">LIVE_MONITOR</s:String>
+	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=Roslyn_002Dswea/@EntryIndexedValue">DO_NOTHING</s:String>
+	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=ShowAnnotations/@EntryIndexedValue">LIVE_MONITOR</s:String>
+	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=SolExp_002DTrack/@EntryIndexedValue">LIVE_MONITOR</s:String>
+	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=StartPage_002DIsDownloadRefreshEnabled/@EntryIndexedValue">LIVE_MONITOR</s:String>
+	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=StartPage_002DOnEnvironmentStatup/@EntryIndexedValue">LIVE_MONITOR</s:String>
+	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=SyncSettings/@EntryIndexedValue">LIVE_MONITOR</s:String>
+	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=TextEditor_002DCodeLens/@EntryIndexedValue">LIVE_MONITOR</s:String>
+	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=TextEditor_002DTrackChanges_002D2/@EntryIndexedValue">LIVE_MONITOR</s:String>
+	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=VCS/@EntryIndexedValue">LIVE_MONITOR</s:String>
+	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=VsBulb/@EntryIndexedValue">DO_NOTHING</s:String>
+	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=XAML_0020Designer/@EntryIndexedValue">LIVE_MONITOR</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECpp_002ECodeStyle_002ESettingsUpgrade_002EFunctionReturnStyleSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECpp_002ECodeStyle_002ESettingsUpgrade_002ENamespaceIndentationSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
@@ -39,4 +96,5 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EFormat_002ESettingsUpgrade_002EAlignmentTabFillStyleMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsParsFormattingSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsWrapperSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Enable pre-configured http clients to be used in the OnPremiseConnector by passing in an factory. Factory uses the same interface like netstandard 2.0 to be able to plug that in with a thin wrapper.