### PR TITLE
Fix issue where only 500 errors and not 5xx were filtered when configured

### DIFF
--- a/Documentation/de/relayserver.md
+++ b/Documentation/de/relayserver.md
@@ -12,6 +12,7 @@
 - Fehlerbehebungen
 
   * Wenn eine weiterzuleitende Anfrage einen Query-Parameter namens 'path' enthielt, führte das zu unerwartetem Verhalten
+  * Die konfigurierbare Filterung des Inhaltes von OnPremise-Seitigen Fehler-Antworten wurde korrigiert
 
 ## Version 2.0.0
 
@@ -65,7 +66,7 @@
   * X-XSS-Protection Header werden nun gesetzt
   * Es ist nun möglich, den Relaying-Endpunkt auf Authentifizierte Requests einzuschränken
 
-- Allgemeine Verbeserungen
+- Allgemeine Verbesserungen
 
   * Info- und Management Endpunkte setzten nun korrekte Cache-Header
   * Update verwendeter Bibliotheken auf die jeweils neueste Version

--- a/Documentation/en/relayserver.md
+++ b/Documentation/en/relayserver.md
@@ -21,6 +21,7 @@ The goal of this list is to highlight companies who pay back to this open source
 - Bug fixes
 
   * When the query to be relayed contained an query argument named 'path', this lead to unexpected behaviour
+  * Corrected the filtering of contents of error responses from on-premise side services when enabled
 
 ## Version 2.0.0
 

--- a/Documentation/en/relayserver.md
+++ b/Documentation/en/relayserver.md
@@ -18,7 +18,7 @@ The goal of this list is to highlight companies who pay back to this open source
 
 ## Version 2.0.1
 
-- Bug fixes
+- Bugfixes
 
   * When the query to be relayed contained an query argument named 'path', this lead to unexpected behaviour
   * Corrected the filtering of contents of error responses from on-premise side services when enabled
@@ -80,7 +80,7 @@ The goal of this list is to highlight companies who pay back to this open source
   * Info and management endpoints now set correct cache headers
   * Dependencies have been updated to their corresponding latest versions
 
-- Bug fixes
+- Bugfixes
 
   * Some operations did not work reliable in the Management Web and have been fixed
 

--- a/Shared/AssemblyInfo.shared.cs
+++ b/Shared/AssemblyInfo.shared.cs
@@ -7,6 +7,6 @@ using System.Reflection;
 [assembly: AssemblyCopyright("Copyright © Thinktecture AG 2015 - 2018. All rights reserved.")]
 [assembly: AssemblyTrademark("Thinktecture RelayServer")]
 
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.0.1.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]
+[assembly: AssemblyInformationalVersion("2.0.1.0")]

--- a/Shared/ProjectProperties.shared.props
+++ b/Shared/ProjectProperties.shared.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- WARNING: This file is shared between all RelayServer .NET Core library projects -->
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
 
     <Copyright>Copyright © Thinktecture AG 2015 - 2018. All rights reserved.</Copyright>
     <PackageTags>thinktecture;relayserver</PackageTags>

--- a/Thinktecture.Relay.Server.Test/Http/HttpResponseMessageBuilderTest.cs
+++ b/Thinktecture.Relay.Server.Test/Http/HttpResponseMessageBuilderTest.cs
@@ -162,10 +162,38 @@ namespace Thinktecture.Relay.Server.Http
 		}
 
 		[TestMethod]
+		public void GetResponseContentForOnPremiseTargetResponse_does_not_disclose_content_when_other_error_occurred_and_ForwardOnPremiseTargetErrorResponse_is_turned_off()
+		{
+			var sut = new HttpResponseMessageBuilder(null, GetInMemoryStore());
+			var onPremiseTargetResponse = new OnPremiseConnectorResponse { StatusCode = HttpStatusCode.NotImplemented };
+			var link = new Link();
+
+			using (var result = sut.GetResponseContentForOnPremiseTargetResponse(onPremiseTargetResponse, link))
+			{
+				result.Should().BeNull();
+			}
+		}
+
+		[TestMethod]
 		public async Task GetResponseContentForOnPremiseTargetResponse_discloses_content_when_InternalServerError_occurred_and_ForwardOnPremiseTargetErrorResponse_is_turned_on()
 		{
 			var sut = new HttpResponseMessageBuilder(null, GetInMemoryStore());
 			var onPremiseTargetResponse = new OnPremiseConnectorResponse { StatusCode = HttpStatusCode.InternalServerError, Body = new byte[] { 0, 0, 0 }, ContentLength = 3, };
+			var link = new Link { ForwardOnPremiseTargetErrorResponse = true };
+
+			using (var result = sut.GetResponseContentForOnPremiseTargetResponse(onPremiseTargetResponse, link))
+			{
+				var body = await result.ReadAsByteArrayAsync();
+				result.Should().NotBeNull();
+				body.LongLength.Should().Be(3L);
+			}
+		}
+
+		[TestMethod]
+		public async Task GetResponseContentForOnPremiseTargetResponse_discloses_content_when_other_error_occurred_and_ForwardOnPremiseTargetErrorResponse_is_turned_on()
+		{
+			var sut = new HttpResponseMessageBuilder(null, GetInMemoryStore());
+			var onPremiseTargetResponse = new OnPremiseConnectorResponse { StatusCode = HttpStatusCode.NotImplemented, Body = new byte[] { 0, 0, 0 }, ContentLength = 3, };
 			var link = new Link { ForwardOnPremiseTargetErrorResponse = true };
 
 			using (var result = sut.GetResponseContentForOnPremiseTargetResponse(onPremiseTargetResponse, link))

--- a/Thinktecture.Relay.Server/Http/HttpResponseMessageBuilder.cs
+++ b/Thinktecture.Relay.Server/Http/HttpResponseMessageBuilder.cs
@@ -66,7 +66,7 @@ namespace Thinktecture.Relay.Server.Http
 			if (response == null)
 				throw new ArgumentNullException(nameof(response));
 
-			if (response.StatusCode == HttpStatusCode.InternalServerError && !link.ForwardOnPremiseTargetErrorResponse)
+			if (response.StatusCode >= HttpStatusCode.InternalServerError && !link.ForwardOnPremiseTargetErrorResponse)
 			{
 				return null;
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinktecture-relayserver",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "RelayServer",
   "main": "gulpfile.js",
   "repository": {


### PR DESCRIPTION
ForwardOnPremiseTargetErrorResponse setting will be respected on all server error codes