### PR TITLE
Interceptors now can read the relay server uri that the client requested

### DIFF
--- a/Documentation/de/relayserver.md
+++ b/Documentation/de/relayserver.md
@@ -20,6 +20,7 @@
 * Allgemeine Verbesserungen
 
   * Die Zeitspanne in der sich On-Premise Connectoren nach einem Verbindungsverlust neu verbinden können ist nun konfigurierbar. Damit kann vermieden werden, dass z.B. bei einem Neustart des Servers alle On-Premise Connectoren innerhalb des gleichen kurzen Zeitfensters erneut verbinden wollen und damit versehentlich eine DDoS-Erkennung auslösen.
+  * Interceptoren haben nun Zugriff auf die lokale Uri, die vom Client angefragt wurde, z.B. um Forwarded-Header zu setzen.
 
 - Fehlerbehebungen
 

--- a/Documentation/en/relayserver.md
+++ b/Documentation/en/relayserver.md
@@ -29,6 +29,7 @@ The goal of this list is to highlight companies who pay back to this open source
 * General improvements
 
   * The On-Premises connectors settings for reconnect timeouts (maximum and minimum) are now configurable, to be able to prevent accidental DDoS detections i.e. when the server restarts and all connectors want to reconnect in the same 30 second window.
+  * Interceptors now can read the local uri that the client requested, i.e. to set forwarded headers.
 
 - Bugfixes
 

--- a/Thinktecture.Relay.Server/Interceptor/InterceptedRequest.cs
+++ b/Thinktecture.Relay.Server/Interceptor/InterceptedRequest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -14,6 +15,9 @@ namespace Thinktecture.Relay.Server.Interceptor
 
 		[JsonIgnore]
 		public IPrincipal ClientUser { get; set; }
+
+		[JsonIgnore]
+		public Uri ClientRequestUri { get; set; }
 
 		public InterceptedRequest(IOnPremiseConnectorRequest other)
 		{

--- a/Thinktecture.Relay.Server/Interceptor/InterceptorManager.cs
+++ b/Thinktecture.Relay.Server/Interceptor/InterceptorManager.cs
@@ -58,6 +58,7 @@ namespace Thinktecture.Relay.Server.Interceptor
 			{
 				ClientIpAddress = GetRemoteIpAddress(request, message),
 				ClientUser = clientUser,
+				ClientRequestUri = message.RequestUri,
 			};
 		}
 

--- a/Thinktecture.Relay/Server/Interceptor/IReadOnlyInterceptedRequest.cs
+++ b/Thinktecture.Relay/Server/Interceptor/IReadOnlyInterceptedRequest.cs
@@ -44,5 +44,10 @@ namespace Thinktecture.Relay.Server.Interceptor
 		/// Gets the client user.
 		/// </summary>
 		IPrincipal ClientUser { get; }
+
+		/// <summary>
+		/// Gets the <see cref="Uri"/> that the client requested.
+		/// </summary>
+		Uri ClientRequestUri { get; }
 	}
 }


### PR DESCRIPTION
Replaces #52 