### PR TITLE
Fixed runtime assembly loading issues with different full framework versions

### DIFF
--- a/Documentation/de/relayserver.md
+++ b/Documentation/de/relayserver.md
@@ -7,6 +7,11 @@
 
 # Release Notes
 
+## Version 2.2.1
+
+* Fehlerbehebungen
+  * Der OnPremiseConnector Demo-Service konnte ein Framwork-Assembly unter bestimmten Voraussetzungen nicht korrekt laden.
+
 ## Version 2.2.0
 
 * RelayServer Windows Docker Container-Unterstützung

--- a/Documentation/de/relayserver.md
+++ b/Documentation/de/relayserver.md
@@ -10,6 +10,7 @@
 ## Version 2.2.1
 
 * Fehlerbehebungen
+
   * Der OnPremiseConnector Demo-Service konnte ein Framwork-Assembly unter bestimmten Voraussetzungen nicht korrekt laden.
 
 ## Version 2.2.0

--- a/Documentation/en/relayserver.md
+++ b/Documentation/en/relayserver.md
@@ -16,6 +16,11 @@ The goal of this list is to highlight companies who pay back to this open source
 
 # Version history
 
+## Version 2.2.1
+
+* Fehlerbehebungen
+  * Under certain circumstances the on-premise connector demo service wasn't able to load a framework assembly.
+
 ## Version 2.2.0
 
 * RelayServer Windows Docker Container support

--- a/Documentation/en/relayserver.md
+++ b/Documentation/en/relayserver.md
@@ -18,7 +18,7 @@ The goal of this list is to highlight companies who pay back to this open source
 
 ## Version 2.2.1
 
-* Fehlerbehebungen
+* Bugfixes
   * Under certain circumstances the on-premise connector demo service wasn't able to load a framework assembly.
 
 ## Version 2.2.0

--- a/Documentation/en/relayserver.md
+++ b/Documentation/en/relayserver.md
@@ -19,6 +19,7 @@ The goal of this list is to highlight companies who pay back to this open source
 ## Version 2.2.1
 
 * Bugfixes
+
   * Under certain circumstances the on-premise connector demo service wasn't able to load a framework assembly.
 
 ## Version 2.2.0

--- a/Shared/AssemblyInfo.shared.cs
+++ b/Shared/AssemblyInfo.shared.cs
@@ -7,6 +7,6 @@ using System.Reflection;
 [assembly: AssemblyCopyright("Copyright © Thinktecture AG 2015 - 2019. All rights reserved.")]
 [assembly: AssemblyTrademark("Thinktecture RelayServer")]
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.2.1.0")]
+[assembly: AssemblyFileVersion("2.2.1.0")]
+[assembly: AssemblyInformationalVersion("2.2.1.0")]

--- a/Shared/ProjectProperties.shared.props
+++ b/Shared/ProjectProperties.shared.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- WARNING: This file is shared between all RelayServer .NET Core library projects -->
   <PropertyGroup>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionPrefix>2.2.1</VersionPrefix>
 
     <Copyright>Copyright © Thinktecture AG 2015 - 2019. All rights reserved.</Copyright>
     <PackageTags>thinktecture;relayserver</PackageTags>

--- a/Thinktecture.Relay.OnPremiseConnector/IdentityModel/AuthenticationException.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/IdentityModel/AuthenticationException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Thinktecture.Relay.OnPremiseConnector.IdentityModel
+{
+	/// <inheritdoc />
+	public class AuthenticationException : Exception
+	{
+		/// <inheritdoc />
+		public AuthenticationException()
+		{
+		}
+
+		/// <inheritdoc />
+		public AuthenticationException(string message)
+			: base(message)
+		{
+		}
+	}
+}

--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnection.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnection.cs
@@ -7,7 +7,6 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
-using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR.Client;

--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/TokenExpiryChecker.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/TokenExpiryChecker.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Security.Authentication;
 using System.Threading.Tasks;
 using Serilog;
+using Thinktecture.Relay.OnPremiseConnector.IdentityModel;
 
 namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 {

--- a/Thinktecture.Relay.OnPremiseConnector/Thinktecture.Relay.OnPremiseConnector.csproj
+++ b/Thinktecture.Relay.OnPremiseConnector/Thinktecture.Relay.OnPremiseConnector.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
 </Project>

--- a/Thinktecture.Relay.OnPremiseConnectorService/App.config
+++ b/Thinktecture.Relay.OnPremiseConnectorService/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <configuration>
 	<configSections>
@@ -65,10 +65,6 @@
       <dependentAssembly>
         <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.8.1.0" newVersion="4.8.1.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Topshelf" publicKeyToken="b800c4cfcdeea87b" culture="neutral" />

--- a/Thinktecture.Relay.OnPremiseConnectorService/Thinktecture.Relay.OnPremiseConnectorService.csproj
+++ b/Thinktecture.Relay.OnPremiseConnectorService/Thinktecture.Relay.OnPremiseConnectorService.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>


### PR DESCRIPTION
Removed reference to System.Net.Security from OPC, to prevent runtime issues between Netstandard 1.3 and 2.0 (and different full framework versions).