### PR TITLE
Setting the SharedKey / OAuthCertificate is required

### DIFF
--- a/Documentation/de/3-installation.md
+++ b/Documentation/de/3-installation.md
@@ -109,6 +109,12 @@ Thinktecture.Relay.Server.exe.config
 
 abgespeichert werden.
 
+## Wichtige Konfigurationseinstellungen
+
+Wird vergessen, die Konfigurationsdatei bereitzustellen, so bricht der RelayServer den Start ab.
+
+Es müssen zumindest die ConnectionStrings zur Datenbank und zur RabbitMQ und das `SharedSecret` bzw. das `OAuthCertificate` konfiguriert werden. Im Multi-Server Betrieb ist auch der `TemporaryRequestStoragePath` anzugeben.
+
 ## Connection Strings
 
 Die Verbindungen des RelayServer zu den beteiligten Tools RabbitMQ und Microsoft SQL Server werden im Abschnitt <connectionStrings></connectionStrings> der Konfigurationsdatei konfiguriert. Standardmäßig finden sich in diesem Abschnitt daher diese beiden Verbindungseinstellungen:

--- a/Documentation/de/relayserver.md
+++ b/Documentation/de/relayserver.md
@@ -7,6 +7,12 @@
 
 # Release Notes
 
+## Version 2.3.0
+
+* Allgemeine Verbesserungen
+
+  * Der RelayServer wart nun wenn die `SharedSecret` Einstellung fehlt und kann, wenn nicht im Multi-Server Betrieb eingesetzt, einen zufälligen Startwert verwenden.
+
 ## Version 2.2.1
 
 * Fehlerbehebungen

--- a/Documentation/de/relayserver.md
+++ b/Documentation/de/relayserver.md
@@ -11,7 +11,7 @@
 
 * Allgemeine Verbesserungen
 
-  * Der RelayServer wart nun wenn die `SharedSecret` Einstellung fehlt und kann, wenn nicht im Multi-Server Betrieb eingesetzt, einen zufälligen Startwert verwenden.
+  * Der RelayServer warnt nun wenn die `SharedSecret` Einstellung fehlt und kann, wenn nicht im Multi-Server Betrieb eingesetzt, einen zufälligen Startwert verwenden.
 
 ## Version 2.2.1
 

--- a/Documentation/en/3-installation.md
+++ b/Documentation/en/3-installation.md
@@ -107,6 +107,12 @@ This configuration file should be saved as
 Thinktecture.Relay.Server.exe.config
 ```
 
+## Important configuration settings
+
+If you do not provide a configuration file, the RelayServer will refuse to start.
+
+You have to provide at least the connection strings to the database and to the RabbitMQ, as well as either the `SharedSecret` or `OAuthCertificate`. If you are running in a Multi-Server environment, you also have to provide the `TemporaryRequestStoragePath`.
+
 ## Connection Strings
 
 The connections of the RelayServer to the RabbitMQ and Microsoft SQL Server tools are configured in the <connectionStrings></ connectionStrings> section of the configuration file. By default, this section contains these two connection settings:

--- a/Documentation/en/relayserver.md
+++ b/Documentation/en/relayserver.md
@@ -16,6 +16,12 @@ The goal of this list is to highlight companies who pay back to this open source
 
 # Version history
 
+## Version 2.3.0
+
+* General improvements
+
+  * The RelayServer now warns when the `SharedSecret` setting is missing and uses a random value to be able to work at all, if it is not configured for Multi-Server operation.
+
 ## Version 2.2.1
 
 * Bugfixes

--- a/Shared/AssemblyInfo.shared.cs
+++ b/Shared/AssemblyInfo.shared.cs
@@ -7,6 +7,6 @@ using System.Reflection;
 [assembly: AssemblyCopyright("Copyright © Thinktecture AG 2015 - 2019. All rights reserved.")]
 [assembly: AssemblyTrademark("Thinktecture RelayServer")]
 
-[assembly: AssemblyVersion("2.2.1.0")]
-[assembly: AssemblyFileVersion("2.2.1.0")]
-[assembly: AssemblyInformationalVersion("2.2.1.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
+[assembly: AssemblyInformationalVersion("2.3.0.0")]

--- a/Shared/ProjectProperties.shared.props
+++ b/Shared/ProjectProperties.shared.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- WARNING: This file is shared between all RelayServer .NET Core library projects -->
   <PropertyGroup>
-    <VersionPrefix>2.2.1</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
 
     <Copyright>Copyright © Thinktecture AG 2015 - 2019. All rights reserved.</Copyright>
     <PackageTags>thinktecture;relayserver</PackageTags>

--- a/Thinktecture.Relay.Server/Config/Configuration.cs
+++ b/Thinktecture.Relay.Server/Config/Configuration.cs
@@ -177,6 +177,22 @@ namespace Thinktecture.Relay.Server.Config
 			SharedSecret = GetValue(nameof(SharedSecret));
 			OAuthCertificate = GetValue(nameof(OAuthCertificate));
 
+			if (String.IsNullOrEmpty(SharedSecret) && String.IsNullOrEmpty(OAuthCertificate))
+			{
+				if (String.IsNullOrEmpty(TemporaryRequestStoragePath))
+				{
+					logger?.Warning("No SharedSecret or OAuthCertificate is configured. Please configure one of them. Continuing with a random value which will make all tokens invalid on restart.");
+					SharedSecret = Convert.ToBase64String(Guid.NewGuid().ToByteArray());
+				}
+				else
+				{
+					var message = "No SharedSecret or OAuthCertificate is configured, and RelayServer is set up for Multi-Server operation. You need to configure either SharedSecret or OAuthCertificate before starting RelayServer.";
+
+					logger?.Error(message);
+					throw new ConfigurationErrorsException(message);
+				}
+			}
+
 			HstsHeaderMaxAge = TimeSpan.FromDays(365);
 			if (TimeSpan.TryParse(GetValue(nameof(HstsHeaderMaxAge)), out tmpTimeSpan))
 			{


### PR DESCRIPTION
Logs when the setting is missing and uses a random value in single-server mode and errors out in multi-server mode. Also adds documentation that this setting is required.

Resolves #147 