### PR TITLE
Send config only to supporting OPCs

### DIFF
--- a/Thinktecture.Relay.Server/Communication/BackendCommunication.cs
+++ b/Thinktecture.Relay.Server/Communication/BackendCommunication.cs
@@ -86,7 +86,10 @@ namespace Thinktecture.Relay.Server.Communication
 
 			_connectionContexts.TryAdd(onPremiseConnectionContext.ConnectionId, onPremiseConnectionContext);
 
-			await ProvideLinkConfigurationAsync(onPremiseConnectionContext).ConfigureAwait(false);
+			if (onPremiseConnectionContext.SupportsConfiguration)
+			{
+				await ProvideLinkConfigurationAsync(onPremiseConnectionContext).ConfigureAwait(false);
+			}
 		}
 
 		public async Task UnregisterOnPremiseConnectionAsync(string connectionId)


### PR DESCRIPTION
This closes https://github.com/thinktecture/relayserver/issues/215.