### PR TITLE
Add normalized name to tenant

### DIFF
--- a/src/Thinktecture.Relay.Server.Abstractions/Persistence/Models/Tenant.cs
+++ b/src/Thinktecture.Relay.Server.Abstractions/Persistence/Models/Tenant.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Thinktecture.Relay.Server.Persistence.Models
 {
@@ -31,6 +32,13 @@ namespace Thinktecture.Relay.Server.Persistence.Models
 		/// <summary>
 		/// The client secrets, used for authentication connectors for this tenant.
 		/// </summary>
+		[JsonIgnore]
 		public List<ClientSecret> ClientSecrets { get; set; }
+
+		/// <summary>
+		/// The normalized (e.g. ToUpperInvariant()) name of the tenant. Use this for case-insensitive comparison in the database.
+		/// </summary>
+		[JsonIgnore]
+		public string NormalizedName { get; set; }
 	}
 }

--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.PostgreSql/Migrations/ConfigurationDb/20200810122742_Add_NormalizedName_To_Tenant.Designer.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.PostgreSql/Migrations/ConfigurationDb/20200810122742_Add_NormalizedName_To_Tenant.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.DbContexts;
@@ -9,9 +10,10 @@ using Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.DbContexts;
 namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.PostgreSql.Migrations.ConfigurationDb
 {
     [DbContext(typeof(RelayServerConfigurationDbContext))]
-    partial class RelayServerConfigurationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200810122742_Add_NormalizedName_To_Tenant")]
+    partial class Add_NormalizedName_To_Tenant
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.PostgreSql/Migrations/ConfigurationDb/20200810122742_Add_NormalizedName_To_Tenant.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.PostgreSql/Migrations/ConfigurationDb/20200810122742_Add_NormalizedName_To_Tenant.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.PostgreSql.Migrations.ConfigurationDb
+{
+    public partial class Add_NormalizedName_To_Tenant : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "NormalizedName",
+                table: "Tenants",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tenants_NormalizedName",
+                table: "Tenants",
+                column: "NormalizedName",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Tenants_NormalizedName",
+                table: "Tenants");
+
+            migrationBuilder.DropColumn(
+                name: "NormalizedName",
+                table: "Tenants");
+        }
+    }
+}

--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer/Migrations/ConfigurationDb/20200810122747_Add_NormalizedName_To_Tenant.Designer.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer/Migrations/ConfigurationDb/20200810122747_Add_NormalizedName_To_Tenant.Designer.cs
@@ -2,41 +2,43 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.DbContexts;
 
-namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.PostgreSql.Migrations.ConfigurationDb
+namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer.Migrations.ConfigurationDb
 {
     [DbContext(typeof(RelayServerConfigurationDbContext))]
-    partial class RelayServerConfigurationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200810122747_Add_NormalizedName_To_Tenant")]
+    partial class Add_NormalizedName_To_Tenant
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
                 .HasAnnotation("ProductVersion", "3.1.3")
-                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+                .HasAnnotation("Relational:MaxIdentifierLength", 128)
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
             modelBuilder.Entity("Thinktecture.Relay.Server.Persistence.Models.ClientSecret", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<DateTime>("Created")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("Expiration")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<Guid>("TenantId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("Value")
                         .IsRequired()
-                        .HasColumnType("character varying(4000)")
+                        .HasColumnType("nvarchar(4000)")
                         .HasMaxLength(4000);
 
                     b.HasKey("Id");
@@ -50,24 +52,24 @@ namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.PostgreSql.M
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("Description")
-                        .HasColumnType("character varying(1000)")
+                        .HasColumnType("nvarchar(1000)")
                         .HasMaxLength(1000);
 
                     b.Property<string>("DisplayName")
-                        .HasColumnType("character varying(200)")
+                        .HasColumnType("nvarchar(200)")
                         .HasMaxLength(200);
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("character varying(100)")
+                        .HasColumnType("nvarchar(100)")
                         .HasMaxLength(100);
 
                     b.Property<string>("NormalizedName")
                         .IsRequired()
-                        .HasColumnType("character varying(100)")
+                        .HasColumnType("nvarchar(100)")
                         .HasMaxLength(100);
 
                     b.HasKey("Id");

--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer/Migrations/ConfigurationDb/20200810122747_Add_NormalizedName_To_Tenant.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer/Migrations/ConfigurationDb/20200810122747_Add_NormalizedName_To_Tenant.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer.Migrations.ConfigurationDb
+{
+    public partial class Add_NormalizedName_To_Tenant : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "NormalizedName",
+                table: "Tenants",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tenants_NormalizedName",
+                table: "Tenants",
+                column: "NormalizedName",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Tenants_NormalizedName",
+                table: "Tenants");
+
+            migrationBuilder.DropColumn(
+                name: "NormalizedName",
+                table: "Tenants");
+        }
+    }
+}

--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer/Migrations/ConfigurationDb/RelayServerConfigurationDbContextModelSnapshot.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer/Migrations/ConfigurationDb/RelayServerConfigurationDbContextModelSnapshot.cs
@@ -19,7 +19,7 @@ namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer.Mi
                 .HasAnnotation("Relational:MaxIdentifierLength", 128)
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
-            modelBuilder.Entity("Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.Entities.ClientSecret", b =>
+            modelBuilder.Entity("Thinktecture.Relay.Server.Persistence.Models.ClientSecret", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -46,7 +46,7 @@ namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer.Mi
                     b.ToTable("ClientSecrets");
                 });
 
-            modelBuilder.Entity("Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.Entities.Tenant", b =>
+            modelBuilder.Entity("Thinktecture.Relay.Server.Persistence.Models.Tenant", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -65,17 +65,25 @@ namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer.Mi
                         .HasColumnType("nvarchar(100)")
                         .HasMaxLength(100);
 
+                    b.Property<string>("NormalizedName")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(100)")
+                        .HasMaxLength(100);
+
                     b.HasKey("Id");
 
                     b.HasIndex("Name")
                         .IsUnique();
 
+                    b.HasIndex("NormalizedName")
+                        .IsUnique();
+
                     b.ToTable("Tenants");
                 });
 
-            modelBuilder.Entity("Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.Entities.ClientSecret", b =>
+            modelBuilder.Entity("Thinktecture.Relay.Server.Persistence.Models.ClientSecret", b =>
                 {
-                    b.HasOne("Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.Entities.Tenant", "Tenant")
+                    b.HasOne("Thinktecture.Relay.Server.Persistence.Models.Tenant", "Tenant")
                         .WithMany("ClientSecrets")
                         .HasForeignKey("TenantId")
                         .OnDelete(DeleteBehavior.Cascade)

--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore/ModelBuilderExtensions.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore/ModelBuilderExtensions.cs
@@ -55,6 +55,15 @@ namespace Microsoft.EntityFrameworkCore
 					.HasForeignKey(cs => cs.TenantId)
 					.IsRequired()
 					.OnDelete(DeleteBehavior.Cascade);
+
+				tenant
+					.Property(t => t.NormalizedName)
+					.HasMaxLength(100)
+					.IsRequired();
+
+				tenant
+					.HasIndex(t => t.NormalizedName)
+					.IsUnique();
 			});
 		}
 

--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore/TenantRepository.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore/TenantRepository.cs
@@ -25,10 +25,12 @@ namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore
 		/// <inheritdoc />
 		public Task<Tenant> LoadTenantByNameAsync(string name)
 		{
+			var normalizedName = name.ToUpperInvariant();
+
 			return _dbContext.Tenants
-				.Include(t => t.ClientSecrets)
+				.Include(tenant => tenant.ClientSecrets)
 				.AsNoTracking()
-				.SingleOrDefaultAsync(t => t.Name == name);
+				.SingleOrDefaultAsync(tenant => tenant.NormalizedName == normalizedName);
 		}
 
 		// TODO: Fix these methods, these are preliminary
@@ -59,6 +61,8 @@ namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore
 			{
 				tenantToCreate.Id = Guid.NewGuid();
 			}
+
+			tenantToCreate.NormalizedName = tenantToCreate.Name.ToUpperInvariant();
 
 			await _dbContext.Tenants.AddAsync(tenantToCreate);
 			await _dbContext.SaveChangesAsync();


### PR DESCRIPTION
Some database engines seem to be case-sensitive during string comparison. For that case the column `NormalizedName` should be used instead (by comparing against a `ToUpperInvariant()` value).

This depends on https://github.com/thinktecture/relayserver/pull/228.