### PR TITLE
Allow rollback of migrations

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -23,7 +23,7 @@ In order to build and run the development environment, you need the following co
 
 After you start the system for the first time, you need to execute the `seed-data.ps1` script, which will create the first initial
 configuration for the tenants, so that the connectors can connect with their default development credentials. After that you can run the
-environment or the multiserver environment.
+environment or the multi-server environment.
 
 The _development_ environment also comes with a [Seq](https://datalust.co/seq) logging server in a local docker container (using the local,
 free single-user license). For production the RelayServer components log to stdout and stderr as this is default in docker environments, but

--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.PostgreSql/Migrations/ConfigurationDb/20200810122742_Add_NormalizedName_To_Tenant.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.PostgreSql/Migrations/ConfigurationDb/20200810122742_Add_NormalizedName_To_Tenant.cs
@@ -13,6 +13,8 @@ namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.PostgreSql.M
                 nullable: false,
                 defaultValue: "");
 
+				migrationBuilder.Sql("UPDATE \"Tenants\" SET \"NormalizedName\" = UPPER(\"Name\")");
+
             migrationBuilder.CreateIndex(
                 name: "IX_Tenants_NormalizedName",
                 table: "Tenants",

--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer/Migrations/ConfigurationDb/20200810122747_Add_NormalizedName_To_Tenant.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer/Migrations/ConfigurationDb/20200810122747_Add_NormalizedName_To_Tenant.cs
@@ -13,6 +13,8 @@ namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer.Mi
                 nullable: false,
                 defaultValue: "");
 
+				migrationBuilder.Sql("UPDATE [Tenants] SET [NormalizedName] = UPPER([Name])");
+
             migrationBuilder.CreateIndex(
                 name: "IX_Tenants_NormalizedName",
                 table: "Tenants",

--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore/ServiceProviderExtensions.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore/ServiceProviderExtensions.cs
@@ -1,7 +1,12 @@
 using System;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.DbContexts;
 
 namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore
@@ -12,15 +17,71 @@ namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore
 	public static class ServiceProviderExtensions
 	{
 		/// <summary>
-		/// Apply the most-recent database migrations.
+		/// Apply the pending database migrations.
 		/// </summary>
 		/// <param name="serviceProvider">An <see cref="IServiceProvider"/>.</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
 		/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-		public static async Task ApplyMigrations(this IServiceProvider serviceProvider)
+		public static async Task ApplyPendingMigrationsAsync(this IServiceProvider serviceProvider,
+			CancellationToken cancellationToken = default)
 		{
-			using var scope = serviceProvider.CreateScope();
-			await using var dbContext = scope.ServiceProvider.GetRequiredService<RelayDbContext>();
-			await dbContext.Database.MigrateAsync();
+			using var scope = GetDbContext(serviceProvider, out var context);
+			var logger = scope.ServiceProvider.GetRequiredService<ILogger<RelayDbContext>>();
+
+			var pending = (await context.Database.GetPendingMigrationsAsync(cancellationToken)).ToArray();
+			if (pending.Length > 0)
+			{
+				logger.LogWarning(
+					$"Applying {{MigrationCount}} pending migration{(pending.Length == 1 ? string.Empty : "s")} (\"{{Migrations}}\")",
+					pending.Length, string.Join("\", \"", pending));
+				await context.Database.MigrateAsync(cancellationToken);
+			}
+			else
+			{
+				logger.LogInformation("No migrations pending");
+			}
+		}
+
+		/// <summary>
+		/// Rolls back the database to a specific migration.
+		/// </summary>
+		/// <param name="serviceProvider">An <see cref="IServiceProvider"/>.</param>
+		/// <param name="targetMigration">The name of the migration to return to.</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+		/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+		public static async Task RollbackMigrationsAsync(this IServiceProvider serviceProvider, string targetMigration,
+			CancellationToken cancellationToken = default)
+		{
+			using var scope = GetDbContext(serviceProvider, out var context);
+			var logger = scope.ServiceProvider.GetRequiredService<ILogger<RelayDbContext>>();
+
+			var applied = (await context.Database.GetAppliedMigrationsAsync(cancellationToken)).ToArray();
+			var migration = applied.FirstOrDefault(m => m.Equals(targetMigration, StringComparison.OrdinalIgnoreCase));
+			if (migration == null)
+			{
+				if (applied.Length == 0)
+				{
+					logger.LogError("Cannot rollback any migrations on a non-migrated database");
+				}
+				else
+				{
+					logger.LogWarning(
+						"The provided target migration \"{TargetMigration}\" was not found in the already applied migrations (\"{Migrations}\")",
+						targetMigration, string.Join("\", \"", applied));
+				}
+			}
+			else
+			{
+				logger.LogWarning("Rolling back to migration {TargetMigration}", migration);
+				await context.GetService<IMigrator>().MigrateAsync(migration, cancellationToken);
+			}
+		}
+
+		private static IServiceScope GetDbContext(IServiceProvider serviceProvider, out RelayDbContext context)
+		{
+			var scope = serviceProvider.CreateScope();
+			context = scope.ServiceProvider.GetRequiredService<RelayDbContext>();
+			return scope;
 		}
 	}
 }

--- a/src/docker/Thinktecture.Relay.Server.Docker/Program.cs
+++ b/src/docker/Thinktecture.Relay.Server.Docker/Program.cs
@@ -20,12 +20,18 @@ namespace Thinktecture.Relay.Server.Docker
 				var config = host.Services.GetRequiredService<IConfiguration>();
 				if (config.GetValue<bool>("migrate") || config.GetValue<bool>("migrate-only"))
 				{
-					Log.Information("Applying migrations");
-					await host.Services.ApplyMigrations();
+					var rollback = config.GetValue<string>("rollback");
+					if (rollback == null)
+					{
+						await host.Services.ApplyPendingMigrationsAsync();
+					}
+					else
+					{
+						await host.Services.RollbackMigrationsAsync(rollback);
+					}
 
 					if (config.GetValue<bool>("migrate-only"))
 					{
-						Log.Information("Only migrations should be executed");
 						return 0;
 					}
 				}


### PR DESCRIPTION
This fixes also a bug in the migration introducing the `NormalizedName` for tenants.