### PR TITLE
Allow to check if any connection is available during relaying

### DIFF
--- a/Documentation/de/3-installation.md
+++ b/Documentation/de/3-installation.md
@@ -169,6 +169,7 @@ Die Standardeinstellungen umfassen dabei:
     <add key="SecureClientController" value="false" />
     <add key="AccessTokenLifetime" value="365.00:00:00" />
     <add key="LogSensitiveData" value="true" />
+    <add key="RequireLinkAvailability" value="false" />
     <add key="LinkTokenRefreshWindow" value="00:01:00" />
     <add key="LinkReconnectMinWaitTime" value="00:00:02" />
     <add key="LinkReconnectMaxWaitTime" value="00:00:30" />
@@ -210,6 +211,7 @@ Die Standardeinstellungen umfassen dabei:
 | SecureClientController | Legt fest, ob ein Client für jeden Request an den `/relay` Endpunkt einen gültigen AccessToken eines On-Premise Connectors / Links mitsenden muss (default false) |
 | AccessTokenLifetime | Zeitspanne für die ein ausgestelltes AccesssToken für On-Premise Connectoren sowie Management Web Benutzer gültig ist (default 365 Tage) <br/> _Hinweis:_ Ein zu kleiner Wert schränkt die Benutzbarkeit des Management Webs ein |
 | LogSensitiveData | Gibt an, ob sensitive Daten der Requests wie Werte von Http-Headern und Query-Parametern gelogged werden sollen (default true) |
+| RequireLinkAvailability | Prüft beim Relayen ob eine Verbindung verfügbar ist und beendet die Anfrage mit HTTP Service Unavailable falls nicht (default false) |
 | LinkTokenRefreshWindow | Default-Zeitspanne, in der ein On-Premise Connector vor dem ungültig werden seines AccessTokens ein neues anfordert (default 1 Minute). Dieser Wert kann pro Link überschrieben werden. |
 | LinkReconnectMinWaitTime | Default-Zeitspanne, nachdem ein On-Premise Connector nach einem Verbindungsverlust die SignalR-Verbindung frühestens wieder aufzubauen versucht (default 2 Sekunden). Dieser Wert kann pro Link überschrieben werden. |
 | LinkReconnectMaxWaitTime | Default-Zeitspanne, nachdem ein On-Premise Connector nach einem Verbindungsverlust die SignalR-Verbindung spätestens wieder aufzubauen versucht (default 30 Sekunden). Dieser Wert kann pro Link überschrieben werden. |

--- a/Documentation/en/3-installation.md
+++ b/Documentation/en/3-installation.md
@@ -167,6 +167,7 @@ The default settings include:
     <add key="SecureClientController" value="false" />
     <add key="AccessTokenLifetime" value="365.00:00:00" />
     <add key="LogSensitiveData" value="true" />
+    <add key="RequireLinkAvailability" value="false" />
     <add key="LinkTokenRefreshWindow" value="00:01:00" />
     <add key="LinkReconnectMinWaitTime" value="00:00:02" />
     <add key="LinkReconnectMaxWaitTime" value="00:00:30" />
@@ -208,6 +209,7 @@ The default settings include:
 | SecureClientController | When set, every request to the `/relay` endpoint must be authorized by a valid On-Premise Connector / Link access token (default false) |
 | AccessTokenLifetime | Time span that an issued access token for On-Premise Connectors and Management Web users will be valid (default 365 days)<br /> _Note:_ If you set this value too short, usability of the Management Web will be affected |
 | LogSensitiveData | Determines whether sensitive data like query parameter values or http header values should be written to the logs (default true) |
+| RequireLinkAvailability | Checks for an available connection before relaying and returns a HTTP Service Unavailable when not available (default false) |
 | LinkTokenRefreshWindow | Default time span, in which an On-Premise Connector will request a new access token, before the current one expires (default 1 minute). This value can be overriden per link. |
 | LinkReconnectMinWaitTime | Default time span, after which an disconnected On-Premise Connector may reconnect to the RelayServer (default 2 seconds). This value can be overriden per link. |
 | LinkReconnectMaxWaitTime | Default time span, after which an disconnected On-Premise Connector will reconnect at the latest (default 30 seconds). This value can be overriden per link. |

--- a/Thinktecture.Relay.Server/App.config
+++ b/Thinktecture.Relay.Server/App.config
@@ -52,6 +52,7 @@
     <add key="SecureClientController" value="false" />
     <add key="AccessTokenLifetime" value="365.00:00:00" />
     <add key="LogSensitiveData" value="true" />
+    <add key="RequireLinkAvailability" value="false" />
 
     <!-- Default for all links -->
     <add key="LinkTokenRefreshWindow" value="00:01:00" />

--- a/Thinktecture.Relay.Server/Config/Configuration.cs
+++ b/Thinktecture.Relay.Server/Config/Configuration.cs
@@ -45,6 +45,7 @@ namespace Thinktecture.Relay.Server.Config
 		public bool SecureClientController { get; }
 		public TimeSpan AccessTokenLifetime { get; }
 		public bool LogSensitiveData { get; }
+		public bool RequireLinkAvailability { get; }
 
 		// Default settings for links
 		public TimeSpan LinkTokenRefreshWindow { get; }
@@ -249,6 +250,12 @@ namespace Thinktecture.Relay.Server.Config
 			if (Boolean.TryParse(GetValue(nameof(LogSensitiveData)), out tmpBool))
 			{
 				LogSensitiveData = tmpBool;
+			}
+
+			RequireLinkAvailability = false;
+			if (Boolean.TryParse(GetValue(nameof(RequireLinkAvailability)), out tmpBool))
+			{
+				RequireLinkAvailability = tmpBool;
 			}
 
 			LinkTokenRefreshWindow = TimeSpan.FromMinutes(1);

--- a/Thinktecture.Relay.Server/Config/IConfiguration.cs
+++ b/Thinktecture.Relay.Server/Config/IConfiguration.cs
@@ -42,5 +42,6 @@ namespace Thinktecture.Relay.Server.Config
 		TimeSpan? LinkAbsoluteConnectionLifetime { get; }
 		TimeSpan? LinkSlidingConnectionLifetime { get; }
 		bool LogSensitiveData { get; }
+		bool RequireLinkAvailability { get; }
 	}
 }

--- a/Thinktecture.Relay.Server/Controller/ResponseController.cs
+++ b/Thinktecture.Relay.Server/Controller/ResponseController.cs
@@ -11,7 +11,9 @@ using Thinktecture.Relay.Server.Communication;
 using Thinktecture.Relay.Server.Http.Filters;
 using Thinktecture.Relay.Server.IO;
 using Thinktecture.Relay.Server.OnPremise;
-using Thinktecture.Relay.Server.SignalR;
+using Thinktecture.Relay.Server.Http;
+using System.Security.Claims;
+using Thinktecture.Relay.Server.Security;
 
 namespace Thinktecture.Relay.Server.Controller
 {
@@ -33,6 +35,10 @@ namespace Thinktecture.Relay.Server.Controller
 
 		public async Task<IHttpActionResult> Forward()
 		{
+			var claimsPrincipal = (ClaimsPrincipal)RequestContext.Principal;
+			var onPremiseId = claimsPrincipal.FindFirst(AuthorizationServerProvider.OnPremiseIdClaimName)?.Value;
+			Request.GetCallCancelled().Register(() => _logger?.Warning("Disconnect during receiving on-premise response detected. link-id={LinkId}", onPremiseId));
+
 			var requestStream = await Request.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
 			OnPremiseConnectorResponse response = null;

--- a/Thinktecture.Relay.Server/Http/HttpRequestMessageExtensions.cs
+++ b/Thinktecture.Relay.Server/Http/HttpRequestMessageExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.ServiceModel.Channels;
+using System.Threading;
 using System.Web;
 using Microsoft.Owin;
 
@@ -9,13 +10,15 @@ namespace Thinktecture.Relay.Server.Http
 {
 	internal static class HttpRequestMessageExtensions
 	{
+		private const string MS_OwinContext = "MS_OwinContext";
+
 		public static IPAddress GetRemoteIpAddress(this HttpRequestMessage request)
 		{
 			string ip = null;
 
-			if (request.Properties.ContainsKey("MS_OwinContext"))
+			if (request.Properties.ContainsKey(MS_OwinContext))
 			{
-				ip = ((OwinContext)request.Properties["MS_OwinContext"]).Request.RemoteIpAddress;
+				ip = ((OwinContext)request.Properties[MS_OwinContext]).Request.RemoteIpAddress;
 			}
 			else if (request.Properties.ContainsKey("MS_HttpContext"))
 			{
@@ -32,6 +35,13 @@ namespace Thinktecture.Relay.Server.Http
 			}
 
 			return String.IsNullOrWhiteSpace(ip) ? null : IPAddress.Parse(ip);
+		}
+
+		public static CancellationToken GetCallCancelled(this HttpRequestMessage request)
+		{
+			return request.Properties.TryGetValue(MS_OwinContext, out object owinContext)
+				? ((OwinContext)owinContext).Request.CallCancelled
+				: CancellationToken.None;
 		}
 	}
 }

--- a/Thinktecture.Relay.Server/Repository/ILinkRepository.cs
+++ b/Thinktecture.Relay.Server/Repository/ILinkRepository.cs
@@ -24,5 +24,7 @@ namespace Thinktecture.Relay.Server.Repository
 		Task RemoveActiveConnectionAsync(string connectionId);
 		void DeleteAllConnectionsForOrigin(Guid originId);
 		LinkConfiguration GetLinkConfiguration(Guid linkId);
+
+		Task<bool> HasActiveConnectionAsync(Guid linkId);
 	}
 }

--- a/Thinktecture.Relay.Server/Repository/LinkRepository.cs
+++ b/Thinktecture.Relay.Server/Repository/LinkRepository.cs
@@ -460,5 +460,23 @@ namespace Thinktecture.Relay.Server.Repository
 				_logger?.Error(ex, "Error during deleting of all active connections");
 			}
 		}
+
+		public async Task<bool> HasActiveConnectionAsync(Guid linkId)
+		{
+			_logger?.Verbose("Checking for active connections");
+
+			try
+			{
+				using (var context = new RelayContext())
+				{
+					return await context.ActiveConnections.AnyAsync(ac => ac.LinkId == linkId);
+				}
+			}
+			catch (Exception ex)
+			{
+				_logger?.Error(ex, "Error during checking for active connections");
+				return false;
+			}
+		}
 	}
 }

--- a/Thinktecture.Relay.Server/Repository/LinkRepository.cs
+++ b/Thinktecture.Relay.Server/Repository/LinkRepository.cs
@@ -463,7 +463,7 @@ namespace Thinktecture.Relay.Server.Repository
 
 		public async Task<bool> HasActiveConnectionAsync(Guid linkId)
 		{
-			_logger?.Verbose("Checking for active connections");
+			_logger?.Verbose("Checking for active connections. link-id={LinkId}", linkId);
 
 			try
 			{

--- a/Thinktecture.Relay.Server/Security/AuthorizationServerProvider.cs
+++ b/Thinktecture.Relay.Server/Security/AuthorizationServerProvider.cs
@@ -10,6 +10,8 @@ namespace Thinktecture.Relay.Server.Security
 		private readonly ILinkRepository _linkRepository;
 		private readonly IUserRepository _userRepository;
 
+		public const string OnPremiseIdClaimName = "OnPremiseId";
+
 		public AuthorizationServerProvider(ILinkRepository linkRepository, IUserRepository userRepository)
 		{
 			_linkRepository = linkRepository;
@@ -42,7 +44,7 @@ namespace Thinktecture.Relay.Server.Security
 			{
 				var identity = new ClaimsIdentity(context.Options.AuthenticationType);
 				identity.AddClaim(new Claim(identity.NameClaimType, context.UserName));
-				identity.AddClaim(new Claim("OnPremiseId", linkId.ToString()));
+				identity.AddClaim(new Claim(OnPremiseIdClaimName, linkId.ToString()));
 				identity.AddClaim(new Claim(identity.RoleClaimType, "OnPremise"));
 
 				context.Validated(identity);

--- a/Thinktecture.Relay.Server/SignalR/OnPremisesConnection.cs
+++ b/Thinktecture.Relay.Server/SignalR/OnPremisesConnection.cs
@@ -9,6 +9,7 @@ using Serilog;
 using Thinktecture.Relay.Server.Communication;
 using Thinktecture.Relay.Server.Config;
 using Thinktecture.Relay.Server.OnPremise;
+using Thinktecture.Relay.Server.Security;
 
 namespace Thinktecture.Relay.Server.SignalR
 {
@@ -34,7 +35,7 @@ namespace Thinktecture.Relay.Server.SignalR
 		{
 			if ((request.User?.Identity.IsAuthenticated ?? false) && request.User is ClaimsPrincipal principal)
 			{
-				var linkId = principal.FindFirst("OnPremiseId")?.Value;
+				var linkId = principal.FindFirst(AuthorizationServerProvider.OnPremiseIdClaimName)?.Value;
 				return !String.IsNullOrWhiteSpace(linkId) && Guid.TryParse(linkId, out var _);
 			}
 
@@ -108,7 +109,7 @@ namespace Thinktecture.Relay.Server.SignalR
 		private static OnPremiseClaims GetOnPremiseClaims(IRequest request)
 		{
 			var claimsPrincipal = (ClaimsPrincipal)request.User;
-			var onPremiseId = claimsPrincipal.FindFirst("OnPremiseId")?.Value;
+			var onPremiseId = claimsPrincipal.FindFirst(AuthorizationServerProvider.OnPremiseIdClaimName)?.Value;
 
 			if (!Guid.TryParse(onPremiseId, out var linkId))
 				throw new ArgumentException($"The claim \"OnPremiseId\" is not valid: {onPremiseId}.");


### PR DESCRIPTION
If `RequireLinkAvailability` is set to `true`, a relay request will instantly be answered with a HTTP status code `Server Unavailable` when no available connection is found in the database.