### PR TITLE
Feat: reconnect when no message received from the server at all

### DIFF
--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/HeartbeatChecker.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/HeartbeatChecker.cs
@@ -22,7 +22,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 				.ForContext("RelayServerConnectionInstanceId", connection.RelayServerConnectionInstanceId);
 
 			var lastHeartbeat = connection.LastHeartbeat;
-			if (lastHeartbeat != DateTime.MinValue && lastHeartbeat != DateTime.MaxValue)
+			if (connection.HeartbeatSupportedByServer && lastHeartbeat != DateTime.MinValue)
 			{
 				if (lastHeartbeat <= DateTime.UtcNow.Subtract(connection.HeartbeatInterval.Add(TimeSpan.FromSeconds(2))))
 				{

--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/HeartbeatChecker.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/HeartbeatChecker.cs
@@ -17,20 +17,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 			if (connection == null)
 				throw new ArgumentNullException(nameof(connection));
 
-			var logger = _logger?
-				.ForContext("RelayServerUri", connection.Uri)
-				.ForContext("RelayServerConnectionInstanceId", connection.RelayServerConnectionInstanceId);
-
-			var lastHeartbeat = connection.LastHeartbeat;
-			if (connection.HeartbeatSupportedByServer && lastHeartbeat != DateTime.MinValue)
-			{
-				if (lastHeartbeat <= DateTime.UtcNow.Subtract(connection.HeartbeatInterval.Add(TimeSpan.FromSeconds(2))))
-				{
-					logger?.Warning("Did not receive expected heartbeat. last-heartbeat={LastHeartbeat}, heartbeat-interval={HeartbeatInterval}, relay-server={RelayServerUri}, relay-server-connection-instance-id={RelayServerConnectionInstanceId}", lastHeartbeat, connection.HeartbeatInterval);
-
-					connection.Reconnect();
-				}
-			}
+			connection.CheckHeartbeat();
 		}
 	}
 }

--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/IRelayServerConnection.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/IRelayServerConnection.cs
@@ -14,9 +14,6 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 		TimeSpan TokenRefreshWindow { get; }
 		DateTime TokenExpiry { get; }
 		int RelayServerConnectionInstanceId { get; }
-		DateTime LastHeartbeat { get; }
-		TimeSpan HeartbeatInterval { get; }
-		bool HeartbeatSupportedByServer { get; }
 
 		DateTime? ConnectedSince { get; }
 		DateTime? LastActivity { get; }
@@ -41,5 +38,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 		Task<HttpResponseMessage> GetToRelayAsync(string relativeUrl, Action<HttpRequestHeaders> setHeaders, CancellationToken cancellationToken);
 		Task<HttpResponseMessage> PostToRelayAsync(string relativeUrl, Action<HttpRequestHeaders> setHeaders, HttpContent content, CancellationToken cancellationToken);
 		Task SendAcknowledgmentAsync(Guid acknowledgeOriginId, string acknowledgeId, string connectionId = null);
+
+		void CheckHeartbeat();
 	}
 }

--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/IRelayServerConnection.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/IRelayServerConnection.cs
@@ -16,6 +16,7 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 		int RelayServerConnectionInstanceId { get; }
 		DateTime LastHeartbeat { get; }
 		TimeSpan HeartbeatInterval { get; }
+		bool HeartbeatSupportedByServer { get; }
 
 		DateTime? ConnectedSince { get; }
 		DateTime? LastActivity { get; }

--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/IRelayServerConnectionFactory.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/IRelayServerConnectionFactory.cs
@@ -5,6 +5,8 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 {
 	internal interface IRelayServerConnectionFactory
 	{
-		IRelayServerConnection Create(Assembly versionAssembly, string userName, string password, Uri relayServer, TimeSpan requestTimeout, TimeSpan tokenRefreshWindow, bool logSensitiveData);
+		IRelayServerConnection Create(Assembly versionAssembly, string userName, string password,
+			Uri relayServer, TimeSpan requestTimeout, TimeSpan tokenRefreshWindow, bool logSensitiveData,
+			bool? heartbeatSupportedByServer);
 	}
 }

--- a/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnectionFactory.cs
+++ b/Thinktecture.Relay.OnPremiseConnector/SignalR/RelayServerConnectionFactory.cs
@@ -22,11 +22,15 @@ namespace Thinktecture.Relay.OnPremiseConnector.SignalR
 			_onPremiseInterceptorFactory = onPremiseInterceptorFactory ?? throw new ArgumentNullException(nameof(onPremiseInterceptorFactory));
 		}
 
-		public IRelayServerConnection Create(Assembly versionAssembly, string userName, string password, Uri relayServer, TimeSpan requestTimeout, TimeSpan tokenRefreshWindow, bool logSensitiveData)
+		public IRelayServerConnection Create(Assembly versionAssembly, string userName, string password, Uri relayServer,
+			TimeSpan requestTimeout, TimeSpan tokenRefreshWindow, bool logSensitiveData,
+			bool? heartbeatSupportedByServer)
 		{
 			_logger?.Information("Creating new connection for RelayServer {RelayServerUrl} and link user {UserName}", relayServer, userName);
 			var httpConnection = new RelayServerHttpConnection(_logger, relayServer, requestTimeout);
-			var signalRConnection = new RelayServerSignalRConnection(versionAssembly, userName, password, relayServer, requestTimeout, tokenRefreshWindow, _onPremiseTargetConnectorFactory, httpConnection, _logger, logSensitiveData, _onPremiseInterceptorFactory);
+			var signalRConnection = new RelayServerSignalRConnection(versionAssembly, userName, password,
+				relayServer, requestTimeout, tokenRefreshWindow, _onPremiseTargetConnectorFactory, httpConnection,
+				_logger, logSensitiveData, _onPremiseInterceptorFactory, heartbeatSupportedByServer);
 
 			// registering connection with maintenance loop
 			_maintenanceLoop.RegisterConnection(signalRConnection);


### PR DESCRIPTION
Sometimes the server may not be able to send any message to the connector, in this case the connector will not check the heartbeat as it thinks the server might be a v1.x server which doesn't support heartbeat
In this pull request, I have added an option to tell the connector that heartbeat is definitely supported by the server, so the connector will check heartbeat and reconnect when there is no message received from server.

This may solve #332, but I'm not able to verify as cannot reproduce #332 any more.

