### PR TITLE
Fix error on disconnect

### DIFF
--- a/Documentation/de/relayserver.md
+++ b/Documentation/de/relayserver.md
@@ -7,6 +7,12 @@
 
 # Release Notes
 
+## Version 2.4.1
+
+* Fehlerbehebungen
+
+  * Ein Connector der die Verbindung verliert sorgt nicht mehr für einen Fehler, der dazu führte, dass der Server ihn noch weiter bedienen will.
+
 ## Version 2.4.0
 
 * Schneller Abbruch

--- a/Documentation/en/relayserver.md
+++ b/Documentation/en/relayserver.md
@@ -17,6 +17,12 @@ The goal of this list is to highlight companies who pay back to this open source
 
 # Version history
 
+## Version 2.4.1
+
+* Bug fixes
+
+  * A disconnecting connector does not throw an error anymore, which caused the server to still try and send messages there.
+
 ## Version 2.4.0
 
 * Fast abort

--- a/Shared/AssemblyInfo.shared.cs
+++ b/Shared/AssemblyInfo.shared.cs
@@ -7,6 +7,6 @@ using System.Reflection;
 [assembly: AssemblyCopyright("Copyright © Thinktecture AG 2015 - 2021. All rights reserved.")]
 [assembly: AssemblyTrademark("Thinktecture RelayServer")]
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
-[assembly: AssemblyInformationalVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.4.1.0")]
+[assembly: AssemblyFileVersion("2.4.1.0")]
+[assembly: AssemblyInformationalVersion("2.4.1.0")]

--- a/Shared/ProjectProperties.shared.props
+++ b/Shared/ProjectProperties.shared.props
@@ -1,8 +1,8 @@
 <Project>
   <!-- WARNING: This file is shared between all RelayServer .NET Core library projects -->
   <PropertyGroup>
-    <VersionPrefix>2.4.0</VersionPrefix>
-    <PackageVersion>2.4.0</PackageVersion>
+    <VersionPrefix>2.4.1</VersionPrefix>
+    <PackageVersion>2.4.1</PackageVersion>
 
     <Copyright>Copyright © Thinktecture AG 2015 - 2021. All rights reserved.</Copyright>
     <PackageTags>thinktecture;relayserver</PackageTags>

--- a/Thinktecture.Relay.OnPremiseConnector/Thinktecture.Relay.OnPremiseConnector.csproj
+++ b/Thinktecture.Relay.OnPremiseConnector/Thinktecture.Relay.OnPremiseConnector.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <Title>Thinktecture RelayServer On Premise Connector</Title>
     <Description>The OnPremiseConnector library should be used to connect to a Thinktecture RelayServer and provide local connectivity. It can be incorporated into services to provide in-process access to local services via the RelayServer. It could also be used in a separate service to provide http(s)-based access to one or multiple services.</Description>
     <Summary>This OnPremiseConnector library should be used to implement local connectors to the Thinktecture RelayServer.</Summary>

--- a/Thinktecture.Relay.Server/Communication/RabbitMq/RabbitMqChannelBase.cs
+++ b/Thinktecture.Relay.Server/Communication/RabbitMq/RabbitMqChannelBase.cs
@@ -223,8 +223,12 @@ namespace Thinktecture.Relay.Server.Communication.RabbitMq
 
 									_observers.Remove(observer);
 
-									_model.BasicCancel(consumer.Tag);
-									_model.BasicRecover(true);
+									if (!String.IsNullOrEmpty(consumer.Tag))
+									{
+										_model.BasicCancel(consumer.Tag);
+										_declaredAndBound = false;
+										consumer.Tag = null;
+									}
 								}
 								else
 								{

--- a/Thinktecture.Relay.Server/Communication/RabbitMq/RabbitMqChannelBase.cs
+++ b/Thinktecture.Relay.Server/Communication/RabbitMq/RabbitMqChannelBase.cs
@@ -134,9 +134,9 @@ namespace Thinktecture.Relay.Server.Communication.RabbitMq
 				// re-attach the consumers
 				foreach (var consumer in _observers.Values)
 				{
-					var consumerTag = consumer.Tag;
+					var oldConsumerTag = consumer.Tag;
 					consumer.Tag = consumer.CreateConsumer();
-					Logger.Verbose("Recreated consumer. exchange-name={ExchangeName}, queue-name={QueueName}, channel-id={ChannelId}, old-consumer-tag={OldConsumerTag}", Exchange, QueueName, ChannelId, consumerTag);
+					Logger.Verbose("Recreated consumer. exchange-name={ExchangeName}, queue-name={QueueName}, channel-id={ChannelId}, consumer-tag={ConsumerTag}, old-consumer-tag={OldConsumerTag}", Exchange, QueueName, ChannelId, consumer.Tag, oldConsumerTag);
 				}
 			}
 		}

--- a/Thinktecture.Relay.Server/Communication/RabbitMq/RabbitMqChannelBase.cs
+++ b/Thinktecture.Relay.Server/Communication/RabbitMq/RabbitMqChannelBase.cs
@@ -177,7 +177,6 @@ namespace Thinktecture.Relay.Server.Communication.RabbitMq
 					string CreateConsumer()
 					{
 						var consumer = new EventingBasicConsumer(_model);
-						_model.BasicConsume(QueueName, autoAck, consumer);
 
 						void OnReceived(object sender, BasicDeliverEventArgs args)
 						{
@@ -202,6 +201,7 @@ namespace Thinktecture.Relay.Server.Communication.RabbitMq
 						}
 
 						consumer.Received += OnReceived;
+						_model.BasicConsume(QueueName, autoAck, consumer);
 
 						Logger.Verbose("Created consumer. exchange-name={ExchangeName}, queue-name={QueueName}, channel-id={ChannelId}, consumer-tag={ConsumerTag}", Exchange, QueueName, ChannelId, consumer.ConsumerTag);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinktecture-relayserver",
-  "version": "2.3.0",
+  "version": "2.4.1",
   "description": "RelayServer",
   "main": "gulpfile.js",
   "repository": {


### PR DESCRIPTION
Besides doble-checking that an empty tag (for whatever reason it got empty...) isn't cancelled anymore,
I also removed the call to the obsolete / deprecated `BasicRecover` method.
`BasicCancel` somehow removes the queue from the channel (model), so we need to rebind the queue after that.

Also fixes a tooling issue, where some IDE got angry when netstandar was only 2 and not 2.0 🤷‍♂️

Closes #347 