### PR TITLE
Correct uri of deep authority urls

### DIFF
--- a/src/Thinktecture.Relay.Connector/Options/AccessTokenManagementConfigureOptions.cs
+++ b/src/Thinktecture.Relay.Connector/Options/AccessTokenManagementConfigureOptions.cs
@@ -30,8 +30,13 @@ namespace Thinktecture.Relay.Connector.Options
 
 		public void Configure(AccessTokenManagementOptions options)
 		{
-			var uri = new Uri(new Uri(_relayConnectorOptions.DiscoveryDocument.AuthorizationServer),
-				OidcConstants.Discovery.DiscoveryEndpoint);
+			var urlString = _relayConnectorOptions.DiscoveryDocument.AuthorizationServer;
+			if (!urlString.EndsWith('/'))
+			{
+				urlString += '/';
+			}
+
+			var uri = new Uri(new Uri(urlString), OidcConstants.Discovery.DiscoveryEndpoint);
 
 			while (!_hostApplicationLifetime.ApplicationStopping.IsCancellationRequested)
 			{


### PR DESCRIPTION
When building a deep uri to an authority (i.e. for keycloak), the missing trailing slash makes the connector to not be able to fetch the OIDC discovery document.
This also can't be simply fixed in the server config by applying a slash there, as then the configured authority does not match with the presented authority in the token.
