### PR TITLE
Fix docker build

### DIFF
--- a/src/Thinktecture.Relay.IdentityServer/Thinktecture.Relay.IdentityServer.csproj
+++ b/src/Thinktecture.Relay.IdentityServer/Thinktecture.Relay.IdentityServer.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Title>Thinktecture RelayServer IdentityServer</Title>
     <Description>Contains support for RelayServer authentication.</Description>
   </PropertyGroup>

--- a/src/docker/Thinktecture.Relay.Connector.Docker/Dockerfile
+++ b/src/docker/Thinktecture.Relay.Connector.Docker/Dockerfile
@@ -22,7 +22,7 @@ RUN dotnet restore Thinktecture.Relay.Connector.Docker.csproj
 FROM restore AS source
 WORKDIR /src
 
-COPY ./shared ./shared
+COPY ./Directory.Build.props ./
 COPY ./docker/Thinktecture.Relay.Docker ./docker/Thinktecture.Relay.Docker
 COPY ./Thinktecture.Relay.Abstractions ./Thinktecture.Relay.Abstractions
 COPY ./Thinktecture.Relay.Connector ./Thinktecture.Relay.Connector

--- a/src/docker/Thinktecture.Relay.IdentityServer.Docker/Dockerfile
+++ b/src/docker/Thinktecture.Relay.IdentityServer.Docker/Dockerfile
@@ -23,7 +23,7 @@ RUN dotnet restore Thinktecture.Relay.IdentityServer.Docker.csproj
 FROM restore AS source
 WORKDIR /src
 
-COPY ./shared ./shared
+COPY ./Directory.Build.props ./
 COPY ./docker/Thinktecture.Relay.Docker ./docker/Thinktecture.Relay.Docker
 COPY ./Thinktecture.Relay.Abstractions ./Thinktecture.Relay.Abstractions
 COPY ./Thinktecture.Relay.Server.Abstractions ./Thinktecture.Relay.Server.Abstractions

--- a/src/docker/Thinktecture.Relay.ManagementApi.Docker/Dockerfile
+++ b/src/docker/Thinktecture.Relay.ManagementApi.Docker/Dockerfile
@@ -22,7 +22,7 @@ RUN dotnet restore Thinktecture.Relay.ManagementApi.Docker.csproj
 FROM restore AS source
 WORKDIR /src
 
-COPY ./shared ./shared
+COPY ./Directory.Build.props ./
 COPY ./docker/Thinktecture.Relay.Docker ./docker/Thinktecture.Relay.Docker
 COPY ./Thinktecture.Relay.Abstractions ./Thinktecture.Relay.Abstractions
 COPY ./Thinktecture.Relay.Server.Abstractions ./Thinktecture.Relay.Server.Abstractions

--- a/src/docker/Thinktecture.Relay.ManagementApi.Docker/run-container.ps1
+++ b/src/docker/Thinktecture.Relay.ManagementApi.Docker/run-container.ps1
@@ -1,7 +1,7 @@
-docker rm -f relay_management
+docker rm -f relay_managementapi
 
 docker run `
-  --name relay_management `
+  --name relay_managementapi `
   --network relay_network `
   --hostname relay_managementapi `
   -p 5004:80 `

--- a/src/docker/Thinktecture.Relay.Server.Docker/Dockerfile
+++ b/src/docker/Thinktecture.Relay.Server.Docker/Dockerfile
@@ -25,7 +25,7 @@ RUN dotnet restore Thinktecture.Relay.Server.Docker.csproj
 FROM restore AS source
 WORKDIR /src
 
-COPY ./shared ./shared
+COPY ./Directory.Build.props ./
 COPY ./docker/Thinktecture.Relay.Docker ./docker/Thinktecture.Relay.Docker
 COPY ./Thinktecture.Relay.Abstractions ./Thinktecture.Relay.Abstractions
 COPY ./Thinktecture.Relay.Server.Abstractions ./Thinktecture.Relay.Server.Abstractions

--- a/src/docker/Thinktecture.Relay.StatisticsApi.Docker/Dockerfile
+++ b/src/docker/Thinktecture.Relay.StatisticsApi.Docker/Dockerfile
@@ -22,7 +22,7 @@ RUN dotnet restore Thinktecture.Relay.StatisticsApi.Docker.csproj
 FROM restore AS source
 WORKDIR /src
 
-COPY ./shared ./shared
+COPY ./Directory.Build.props ./
 COPY ./docker/Thinktecture.Relay.Docker ./docker/Thinktecture.Relay.Docker
 COPY ./Thinktecture.Relay.Abstractions ./Thinktecture.Relay.Abstractions
 COPY ./Thinktecture.Relay.Server.Abstractions ./Thinktecture.Relay.Server.Abstractions


### PR DESCRIPTION
When changing from the ./shared folder to `Directory.build.props`, that wasn't accounted for in the docker build files.
Also, in Docker the missing TragetFramework node in the IdSrv project made `dotnet restore` fail.

This also renames the `management` container to `managementapi`, to be in line with the `statisticsapi` container name.