### PR TITLE
Fix: connections were left over in the database if server crashed and brought up by AutoScalingGroup

### DIFF
--- a/Thinktecture.Relay.Server/Communication/BackendCommunication.cs
+++ b/Thinktecture.Relay.Server/Communication/BackendCommunication.cs
@@ -57,6 +57,7 @@ namespace Thinktecture.Relay.Server.Communication
 		public void Prepare()
 		{
 			_linkRepository.DeleteAllConnectionsForOrigin(OriginId);
+			_linkRepository.DeleteAllOldConnections();
 			_responseSubscription = StartReceivingResponses();
 			_acknowledgeSubscription = StartReceivingAcknowledges();
 		}

--- a/Thinktecture.Relay.Server/Repository/ILinkRepository.cs
+++ b/Thinktecture.Relay.Server/Repository/ILinkRepository.cs
@@ -27,5 +27,7 @@ namespace Thinktecture.Relay.Server.Repository
 		LinkConfiguration GetLinkConfiguration(Guid linkId);
 
 		Task<bool> HasActiveConnectionAsync(Guid linkId);
+
+		void DeleteAllOldConnections();
 	}
 }

--- a/Thinktecture.Relay.Server/Repository/LinkRepository.cs
+++ b/Thinktecture.Relay.Server/Repository/LinkRepository.cs
@@ -548,6 +548,24 @@ namespace Thinktecture.Relay.Server.Repository
 			}
 		}
 
+		public void DeleteAllOldConnections()
+		{
+			_logger?.Verbose("Deleting all old inactive connections.");
+
+			try
+			{
+				using (var context = new RelayContext())
+				{
+					context.Database.ExecuteSqlCommand($"Delete from ActiveConnections Where LastActivity < {DateTime.UtcNow.AddDays(-1):yyyy-MM-dd HH:mm:ss}");
+					context.SaveChanges();
+				}
+			}
+			catch (Exception ex)
+			{
+				_logger?.Error(ex, "Error during deleting of all old inactive connections.");
+			}
+		}
+
 		public async Task<bool> HasActiveConnectionAsync(Guid linkId)
 		{
 			_logger?.Verbose("Checking for active connections. link-id={LinkId}", linkId);


### PR DESCRIPTION
the new EC2 instance will have different origin id thus the connections from the older server will be
left in db forever