### PR TITLE
Re-introduce RequireLinkAvailability feature to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ exchangeable way for you to build your own product and services with RelayServer
 - See [modules](./docs/modules.md) for an overview of the new modular design of RelayServer 3 and modules supported out
   of the box.
 - See [migration](./docs/migration.md) for some ideas how to migrate from RelayServer 2 to version 3.
+- See [configuration](./docs/configuration.md) for some guidance on how to configure the RelayServer 3 components.
 
 ## Features
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,172 @@
+# RelayServer configuration
+
+## Server
+
+The `RelayServerOptions` type provides the main configuration for the server. These are
+the available settings:
+
+```
+{
+    "RelayServer": {
+      // Default request expiration, Timespan, defaults to 10 seconds
+      // Defines how long a request is kept in the system without expiring.
+      "DefaultRequestExpiration": "00:00:10",
+      
+      // Enable connector transport shortcut, Boolean, defaults to false
+      // When enabled, a request can be send directly to a connector
+      "EnableConnectorTransportShortcut": false,
+      
+      // Enable server transport shortcut, Boolean, defaults to false
+      // When enabled, a response can be send directly to the client
+      "EnableServerTransportShortcut": false,
+      
+      // Enpoint timeout, Timespan, defaults to 2 minutes
+      // A connector will wait this long for a on-premises target to respond.
+      "EndpointTimeout": "00:02:00",
+      
+      // Request expiration, Timespan, defaults to DefaultRequestExpiration
+      // The expiration time of a request until a response must be received.
+      "RequestExpiration": "00:00:10",
+      
+      // Reconnect minimum delay, Timespan, defaults to 30 seconds
+      // When a connector gets disconnected, it will wait at least this time before
+      // attempting to reconnect.
+      "ReconnectMinimumDelay": "00:00:30",
+      
+      // Reconnect maximum delay, Timespan, defaults to 5 minutes
+      // When a connector gets disconnected, it will wait at most this time before
+      // attempting to reconnect.
+      "ReconnectMaximumDelay": "00:05:00",
+      
+      // Handshake timeout, Timespan, defaults to 15 seconds
+      // The time in which a handshake between the server and a connector needs to be
+      // completed before rejecting the connection.
+      "HandshakeTimeout": "00:00:15",
+      
+      // Keep alive interval, Timespan, defaults to 15 seconds
+      // The interval in which a keep alive ping is expected between connector and
+      // server. By default the SignalR keepalive is set to this value.
+      "KeepAliveInterval": "00:00:15",
+      
+      // Request logger level, FLAGGED ENUM, defaults to "All"
+      // The verbosity of the IRelayRequestLogger.
+      // Values: 0 = None, 1 = Succeeded, 2 = Aborted, 4 = Failed, 8 = Expired,
+      // 16 = Errored, All = Succeeded | Aborted | Failed | Expired | Errored
+      "RequestLoggerLevel": "All",
+
+      // Acknowledge mode, ENUM, defaults to "Disabled"
+      // Defines the mode in which requests are acknowledged on the server transport.
+      // Values: 0 = Disabled, 1 = ConnectorReceived, 2 = ConnectorFinished, 3 = Manual
+      "AcknowledgeMode": "Disabled",
+
+      // Tenant info cache timeout, Timespan, defaults to 10 seconds
+      // Defines how long the tenant info will be cached before the database is queried
+      // again.
+      "TenantInfoCacheTimeout": "00:00:10",
+
+      // Require active connection, boolean, defaults to false
+      // When enabled, a request is immediately rejected with a 503 Service unavailable
+      // when there is no connector connected for the requested tenant. Otherwise the
+      // request will time out a bit later.
+      "RequireActiveConnection": false,
+  }
+}
+```
+
+The `MaintenanceOptions` type provides the maintenance configuration for the server.
+These are the available settings:
+
+```
+{
+   "Maintenance": {
+      // Run interval, TimeSpan, defaults to 15 minutes
+      // The interval in which maintenance jobs will be run.
+      "RunInterval": "00:15:00",
+   }
+}
+```
+
+The `StatisticsOptions` type provides the statistic data configuration for the server.
+These are the available settings:
+
+```
+{
+   "Statistics": {
+      // Entry max age, TimeSpan, defaults to 15 minutes
+      // The time span to keep stale or closed connection and origin entries in the
+      // statistics store.
+      "EntryMaxAge": "00:15:00",
+      
+      // Last activity update interval, TimeSpan, defaults to 5 minutes
+      // The time interval in which the origin's last activity will be updated.
+      "LastActivityUpdateInterval": "00:05:00",
+      
+      // Enable connection cleanup, boolean, defaults to false
+      // Indicates whether to clean up stale or closed connections or not.
+      "EnableConnectionCleanup": false,
+   }
+}
+```
+
+
+### Corresponding features
+
+#### Transport shortcuts
+
+When a client request reaches a RelayServer instance and the requested tenant has a
+connector that is currently connected to this very same RelayServer instance, it is
+possible to send the request directly to that connector without going through the
+message queue.
+
+If a response is sent to a RelayServer instance from a connector, and the client waiting
+for the response also is connected to the very same RelayServer instance, it is again
+possible to use a shortcut and directly deliver the response without sending it through
+the message queue.
+
+#### Reconnect delay
+
+The reconnect delay is a feature that helps to prevent accidental self-DDoS (distributed
+denial of service) scenarios.
+
+If, for example, RelayServer gets updated, then the old instances shut down and the new
+instances spin up. This will disconnect _all_ connectors from your RelayServer at once.
+If all these connectors would try to reconnect immediately, this would mean a lot of
+different IPs requesting your service at once. Depending on your hosting infrastructure
+or your hosting service provide, this might be recognized as the beginning of a DDoS
+attack, leading to the IP addresses getting blocked from the provider.
+
+The reconnect delay creates a larger time frame for the connectors to reconnect. Each
+connector will determine a random point in time, within the minimum and maximum limits,
+at which to start reconnecting. Randomizing the value should lead to a evenly
+distributed reconnect load.
+
+Suggestion: The more connectors there are in a given relay system, the larger the
+reconnect time window should be to keep the reconnect attempts per second low.
+
+### Require active connection
+
+When a request is received from a client, the RelayServer checks if the requested tenant
+exists in the database. When `RequireActiveConnection` is enabled, it will also check if
+there are any active connections listed in the database. If this is not the case, the
+request will be immediately rejected with a 503 - Service unavailable status code.
+
+__Caution__: This feature relies on the connection info from the database as one
+RelayServer instance does not directly know if there is a connection available on
+another RelayServer instance. If a RelayServer instance with active connections to it
+does not shut down gracefully, i.e. because of a hardware issue killing all containers
+running on a kubernetes node, the connections to that instance will still be listed as
+active in the database. They will remain in the database until the maintenance job
+removes the the old origin and all of its stale connections.
+
+A stale origin is defined by the `EntryMaxAge` statistics option, and the maintenance
+job is executed as often as the `RunInterval` maintenance option defines. With the
+default settings, unavailable connections will be kept for at least 15 up to 30 minutes.
+This will lead to requests for these tenants not being immediately rejected for that
+time.
+
+We suggest that you run the maintenance job more often by reducing the `RunInterval`
+maintenance option, and to not keep old origins / RelayServer instances with their
+connections as long in the database by also reducing the `EntryMaxAge` statistics
+option. The last activity of an origin should be updated at least twice within this
+range, so you might also want to reduce the `LastActivityUpdateInterval` statistics
+option. 

--- a/src/Thinktecture.Relay.Server.Abstractions/RelayServerOptions.cs
+++ b/src/Thinktecture.Relay.Server.Abstractions/RelayServerOptions.cs
@@ -70,9 +70,9 @@ public class RelayServerOptions
 	public AcknowledgeMode AcknowledgeMode { get; set; } = AcknowledgeMode.Disabled;
 
 	/// <summary>
-	/// Determines how long the tenant id should be cached.
+	/// Determines how long the tenant info should be cached.
 	/// </summary>
-	public TimeSpan TenantIdCacheTimeout { get; set; } = TimeSpan.FromSeconds(10);
+	public TimeSpan TenantInfoCacheTimeout { get; set; } = TimeSpan.FromSeconds(10);
 
 	/// <summary>
 	/// Defines if a request should be immediately rejected if there is no active connection available for the

--- a/src/Thinktecture.Relay.Server.Abstractions/RelayServerOptions.cs
+++ b/src/Thinktecture.Relay.Server.Abstractions/RelayServerOptions.cs
@@ -73,4 +73,10 @@ public class RelayServerOptions
 	/// Determines how long the tenant id should be cached.
 	/// </summary>
 	public TimeSpan TenantIdCacheTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+	/// <summary>
+	/// Defines if a request should be immediately rejected if there is no active connection available for the
+	/// requested tenant.
+	/// </summary>
+	public bool RequireActiveConnection { get; set; } = false;
 }

--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore/StatisticsService.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore/StatisticsService.cs
@@ -217,7 +217,7 @@ public partial class StatisticsService : IStatisticsService
 	}
 
 	[LoggerMessage(23314, LogLevel.Debug,
-		"Cleaning up statistics storage by deleting all connections that have no activity since {ConnectionLastActivity}")]
+		"Cleaning up statistics storage by deleting all connections that have no activity or are disconnected since {ConnectionLastActivity}")]
 	partial void LogConnectionCleanup(DateTimeOffset connectionLastActivity);
 
 	/// <inheritdoc/>
@@ -228,8 +228,10 @@ public partial class StatisticsService : IStatisticsService
 
 		try
 		{
-			var connections = await _dbContext.Connections.Where(c => c.LastActivityTime < lastActivity)
+			var connections = await _dbContext.Connections
+				.Where(c => c.LastActivityTime < lastActivity || c.DisconnectTime < lastActivity)
 				.ToArrayAsync(cancellationToken);
+
 			_dbContext.Connections.RemoveRange(connections);
 			await _dbContext.SaveChangesAsync(cancellationToken);
 		}

--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore/TenantService.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore/TenantService.cs
@@ -26,6 +26,7 @@ public class TenantService : ITenantService
 
 		return await _dbContext.Tenants
 			.Include(tenant => tenant.ClientSecrets)
+			.Include(tenant => tenant.Connections)
 			.AsNoTracking()
 			.SingleOrDefaultAsync(tenant => tenant.NormalizedName == normalizedName);
 	}

--- a/src/Thinktecture.Relay.Server/Middleware/RelayMiddleware.cs
+++ b/src/Thinktecture.Relay.Server/Middleware/RelayMiddleware.cs
@@ -349,7 +349,7 @@ public partial class RelayMiddleware<TRequest, TResponse, TAcknowledge> : IMiddl
 		}
 
 		var cacheEntryOptions = new DistributedCacheEntryOptions()
-			.SetAbsoluteExpiration(_relayServerOptions.TenantIdCacheTimeout);
+			.SetAbsoluteExpiration(_relayServerOptions.TenantInfoCacheTimeout);
 
 		cachedData = result.ToByteArray();
 		await _cache.SetAsync(cacheKey, cachedData, cacheEntryOptions, cancellationToken);

--- a/src/Thinktecture.Relay.Server/Middleware/RelayMiddleware.cs
+++ b/src/Thinktecture.Relay.Server/Middleware/RelayMiddleware.cs
@@ -119,6 +119,9 @@ public partial class RelayMiddleware<TRequest, TResponse, TAcknowledge> : IMiddl
 	[LoggerMessage(20605, LogLevel.Information, "Request {RelayRequestId} expired")]
 	partial void LogRequestExpired(Guid relayRequestId);
 
+	[LoggerMessage(20616, LogLevel.Debug, "Request to tenant {Tenant} was rejected due to no active connection")]
+	partial void LogNoActiveConnection(string tenant);
+
 	/// <inheritdoc/>
 	public async Task InvokeAsync(HttpContext context, RequestDelegate next)
 	{
@@ -140,6 +143,7 @@ public partial class RelayMiddleware<TRequest, TResponse, TAcknowledge> : IMiddl
 
 		if (_relayServerOptions.RequireActiveConnection && !tenant.HasActiveConnections)
 		{
+			LogNoActiveConnection(tenantName);
 			context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
 			return;
 		}

--- a/src/Thinktecture.Relay.sln
+++ b/src/Thinktecture.Relay.sln
@@ -27,6 +27,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{EEE512D2-C
 		..\docs\getting-started.md = ..\docs\getting-started.md
 		..\docs\migration.md = ..\docs\migration.md
 		..\docs\modules.md = ..\docs\modules.md
+		..\docs\configuration.md = ..\docs\configuration.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assets", "assets", "{AD756171-B728-4FD3-9BC6-20C2E32141C6}"

--- a/src/docker/Thinktecture.Relay.Server.Docker/appsettings.json
+++ b/src/docker/Thinktecture.Relay.Server.Docker/appsettings.json
@@ -33,5 +33,8 @@
     "LastActivityUpdateInterval": "00:01:00",
     // one minute, default: 5 minutes
     "EnableConnectionCleanup": false
+  },
+  "RelayServer": {
+    "RequireActiveConnection": true
   }
 }


### PR DESCRIPTION
@thomashilzendegen As a second thought... this might be not good enough.

If a server crashes, the connection entries stay in the db, and are not marked as disconnected. Also, the origin stays in the db for some time.

The lastSeenTime of the origin is updated every 5 minutes.

The maintenance job of other origins, that will clean up stale origins (and their corresponding aborted connections), runs every 15 minutes. It removes all origins that have not been seen since 15 minutes. So in the worst case we have a cleanup run, origin last seen update, immediately origin crash, next cleanup run (15 mins later) won't catch that since the last seen was updated rat 14:59 or so. So that means we keep the origin entry and all connections (that still seem to be active) in the db for about 30 minutes. In the best case we still have a 15 minute delay by default.

During that time, requests will be accepted although there are no active connections.

Of course the times are all customizable and we can tune them down to mere seconds, so that the caching of the tenant information is the longest delay factor, but that will be more work for the db then.
Also, should we document this behaviour?