### PR TITLE
Fix overwrittten requestId in ASP.NET Core logging

### DIFF
--- a/src/Thinktecture.Relay.Connector.Protocols.SignalR/AcknowledgeTransport.cs
+++ b/src/Thinktecture.Relay.Connector.Protocols.SignalR/AcknowledgeTransport.cs
@@ -19,7 +19,7 @@ public class AcknowledgeTransport<T> : IAcknowledgeTransport<T>
 	// (see https://github.com/dotnet/runtime/issues/69490)
 	private readonly Action<ILogger, IAcknowledgeRequest, Guid, string?, Exception?> _logTransportingAck =
 		LoggerMessage.Define<IAcknowledgeRequest, Guid, string?>(LogLevel.Trace, 11100,
-			"Transporting acknowledge request {@AcknowledgeRequest} for request {RequestId} on connection {ConnectionId}");
+			"Transporting acknowledge request {@AcknowledgeRequest} for request {RelayRequestId} on connection {ConnectionId}");
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="AcknowledgeTransport{T}"/> class.
@@ -45,7 +45,7 @@ public class AcknowledgeTransport<T> : IAcknowledgeTransport<T>
 		catch (Exception ex)
 		{
 			_logger.LogError(11101, ex,
-				"An error occured while transporting acknowledge for request {RequestId} on connection {ConnectionId}",
+				"An error occured while transporting acknowledge for request {RelayRequestId} on connection {ConnectionId}",
 				request.RequestId, _hubConnection.ConnectionId);
 		}
 	}

--- a/src/Thinktecture.Relay.Connector.Protocols.SignalR/ConnectorConnection.cs
+++ b/src/Thinktecture.Relay.Connector.Protocols.SignalR/ConnectorConnection.cs
@@ -22,13 +22,13 @@ public class ConnectorConnection<TRequest, TResponse, TAcknowledge> : IConnector
 	// (see https://github.com/dotnet/runtime/issues/69490)
 	private readonly Action<ILogger, Guid, string, IClientRequest, Exception?> _logHandlingRequestDetailed =
 		LoggerMessage.Define<Guid, string, IClientRequest>(LogLevel.Trace, 11200,
-			"Handling request {RequestId} on connection {ConnectionId} {@Request}");
+			"Handling request {RelayRequestId} on connection {ConnectionId} {@Request}");
 
 	// TODO move to LoggerMessage source generator when destructuring is supported
 	// (see https://github.com/dotnet/runtime/issues/69490)
 	private readonly Action<ILogger, Guid, string, Guid, Exception?> _logHandlingRequestSimple =
 		LoggerMessage.Define<Guid, string, Guid>(LogLevel.Debug, 11201,
-			"Handling request {RequestId} on connection {ConnectionId} from origin {OriginId}");
+			"Handling request {RelayRequestId} on connection {ConnectionId} from origin {OriginId}");
 
 	private readonly DiscoveryDocumentRetryPolicy _retryPolicy;
 

--- a/src/Thinktecture.Relay.Connector.Protocols.SignalR/ResponseTransport.cs
+++ b/src/Thinktecture.Relay.Connector.Protocols.SignalR/ResponseTransport.cs
@@ -19,7 +19,7 @@ public class ResponseTransport<T> : IResponseTransport<T>
 	// (see https://github.com/dotnet/runtime/issues/69490)
 	private readonly Action<ILogger, ITargetResponse, Guid, string?, Exception?> _logTransportingResponse =
 		LoggerMessage.Define<ITargetResponse, Guid, string?>(LogLevel.Trace, 11500,
-			"Transporting response {@Response} for request {RequestId} on connection {ConnectionId}");
+			"Transporting response {@Response} for request {RelayRequestId} on connection {ConnectionId}");
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ResponseTransport{T}"/> class.
@@ -44,7 +44,7 @@ public class ResponseTransport<T> : IResponseTransport<T>
 		catch (Exception ex)
 		{
 			_logger.LogError(11501, ex,
-				"An error occured while transporting response for request {RequestId} on connection {ConnectionId}",
+				"An error occured while transporting response for request {RelayRequestId} on connection {ConnectionId}",
 				response.RequestId, _hubConnection.ConnectionId);
 		}
 	}

--- a/src/Thinktecture.Relay.Connector/Targets/ClientRequestHandler.cs
+++ b/src/Thinktecture.Relay.Connector/Targets/ClientRequestHandler.cs
@@ -86,8 +86,8 @@ public partial class ClientRequestHandler<TRequest, TResponse, TAcknowledge> : I
 			request.EnableTracing);
 	}
 
-	[LoggerMessage(10400, LogLevel.Debug, "Acknowledging request {RequestId} on origin {OriginId}")]
-	partial void LogAcknowledgeRequest(Guid requestId, Guid? originId);
+	[LoggerMessage(10400, LogLevel.Debug, "Acknowledging request {RelayRequestId} on origin {OriginId}")]
+	partial void LogAcknowledgeRequest(Guid relayRequestId, Guid? originId);
 
 	/// <inheritdoc/>
 	public async Task AcknowledgeRequestAsync(TRequest request, bool removeRequestBodyContent)
@@ -129,12 +129,12 @@ public partial class ClientRequestHandler<TRequest, TResponse, TAcknowledge> : I
 		}
 		catch (Exception ex)
 		{
-			_logger.LogError(10401, ex, "An error occured during handling of request {RequestId}", request.RequestId);
+			_logger.LogError(10401, ex, "An error occured during handling of request {RelayRequestId}", request.RequestId);
 		}
 	}
 
-	[LoggerMessage(10402, LogLevel.Debug, "Delivering response for request {RequestId}")]
-	partial void LogDeliverResponse(Guid requestId);
+	[LoggerMessage(10402, LogLevel.Debug, "Delivering response for request {RelayRequestId}")]
+	partial void LogDeliverResponse(Guid relayRequestId);
 
 	private async Task DeliverResponseAsync(TResponse response, bool enableTracing)
 	{

--- a/src/Thinktecture.Relay.Connector/Targets/ClientRequestWorker.cs
+++ b/src/Thinktecture.Relay.Connector/Targets/ClientRequestWorker.cs
@@ -63,29 +63,29 @@ public partial class ClientRequestWorker<TRequest, TResponse> : IClientRequestWo
 		_responseEndpoint = new Uri($"{relayConnectorOptions.Value.DiscoveryDocument.ResponseEndpoint}/");
 	}
 
-	[LoggerMessage(10500, LogLevel.Trace, "Found target {Target} for request {RequestId}")]
-	partial void LogFoundTarget(string target, Guid requestId);
+	[LoggerMessage(10500, LogLevel.Trace, "Found target {Target} for request {RelayRequestId}")]
+	partial void LogFoundTarget(string target, Guid relayRequestId);
 
 	[LoggerMessage(10501, LogLevel.Debug,
-		"Requesting outsourced request body for request {RequestId} with {BodySize} bytes")]
-	partial void LogRequestingBody(Guid requestId, long? bodySize);
+		"Requesting outsourced request body for request {RelayRequestId} with {BodySize} bytes")]
+	partial void LogRequestingBody(Guid relayRequestId, long? bodySize);
 
-	[LoggerMessage(10502, LogLevel.Debug, "Requesting target {Target} for request {RequestId}")]
-	partial void LogRequestingTarget(string target, Guid requestId);
+	[LoggerMessage(10502, LogLevel.Debug, "Requesting target {Target} for request {RelayRequestId}")]
+	partial void LogRequestingTarget(string target, Guid relayRequestId);
 
 	[LoggerMessage(10503, LogLevel.Debug,
-		"Unknown response body size triggered mandatory outsourcing for request {RequestId}")]
-	partial void LogOutsourcingUnknownBody(Guid requestId);
+		"Unknown response body size triggered mandatory outsourcing for request {RelayRequestId}")]
+	partial void LogOutsourcingUnknownBody(Guid relayRequestId);
 
 	[LoggerMessage(10504, LogLevel.Debug,
-		"Outsourcing from response {BodySize} bytes because of a maximum of {BinarySizeThreshold} for request {RequestId}")]
-	partial void LogOutsourcingBody(long? bodySize, int? binarySizeThreshold, Guid requestId);
+		"Outsourcing from response {BodySize} bytes because of a maximum of {BinarySizeThreshold} for request {RelayRequestId}")]
+	partial void LogOutsourcingBody(long? bodySize, int? binarySizeThreshold, Guid relayRequestId);
 
-	[LoggerMessage(10505, LogLevel.Debug, "Outsourced from response {BodySize} bytes for request {RequestId}")]
-	partial void LogOutsourcedBody(long bodySize, Guid requestId);
+	[LoggerMessage(10505, LogLevel.Debug, "Outsourced from response {BodySize} bytes for request {RelayRequestId}")]
+	partial void LogOutsourcedBody(long bodySize, Guid relayRequestId);
 
-	[LoggerMessage(10506, LogLevel.Debug, "Inlined from response {BodySize} bytes for request {RequestId}")]
-	partial void LogInlinedBody(long? bodySize, Guid requestId);
+	[LoggerMessage(10506, LogLevel.Debug, "Inlined from response {BodySize} bytes for request {RelayRequestId}")]
+	partial void LogInlinedBody(long? bodySize, Guid relayRequestId);
 
 	/// <inheritdoc/>
 	public async Task<TResponse> HandleAsync(TRequest request, CancellationToken cancellationToken = default)
@@ -102,7 +102,8 @@ public partial class ClientRequestWorker<TRequest, TResponse> : IClientRequestWo
 				if (!_relayTargetRegistry.TryCreateRelayTarget(request.Target, scope.ServiceProvider, out target,
 					    out timeout))
 				{
-					_logger.LogInformation(10507, "Could not find any target for request {RequestId} named {Target}",
+					_logger.LogInformation(10507,
+						"Could not find any target for request {RelayRequestId} named {Target}",
 						request.RequestId,
 						request.Target);
 					return request.CreateResponse<TResponse>(HttpStatusCode.NotFound);
@@ -127,7 +128,8 @@ public partial class ClientRequestWorker<TRequest, TResponse> : IClientRequestWo
 					}
 					catch (Exception ex)
 					{
-						_logger.LogError(10508, ex, "An error occured while downloading the body of request {RequestId}",
+						_logger.LogError(10508, ex,
+							"An error occured while downloading the body of request {RelayRequestId}",
 							request.RequestId);
 						return request.CreateResponse<TResponse>(HttpStatusCode.BadGateway);
 					}
@@ -178,7 +180,7 @@ public partial class ClientRequestWorker<TRequest, TResponse> : IClientRequestWo
 					if (!responseMessage.IsSuccessStatusCode)
 					{
 						_logger.LogError(10509,
-							"Uploading body of request {RequestId} failed with http status {HttpStatusCode}",
+							"Uploading body of request {RelayRequestId} failed with http status {HttpStatusCode}",
 							request.RequestId,
 							responseMessage.StatusCode);
 						return request.CreateResponse<TResponse>(HttpStatusCode.BadGateway);
@@ -190,7 +192,8 @@ public partial class ClientRequestWorker<TRequest, TResponse> : IClientRequestWo
 				}
 				catch (Exception ex)
 				{
-					_logger.LogError(10510, ex, "An error occured while uploading the body of request {RequestId}",
+					_logger.LogError(10510, ex,
+						"An error occured while uploading the body of request {RelayRequestId}",
 						request.RequestId);
 					return request.CreateResponse<TResponse>(HttpStatusCode.BadGateway);
 				}
@@ -213,12 +216,13 @@ public partial class ClientRequestWorker<TRequest, TResponse> : IClientRequestWo
 		{
 			if (timeout == null || !timeout.IsCancellationRequested) throw;
 
-			_logger.LogWarning(10511, "The request {RequestId} timed out", request.RequestId);
+			_logger.LogWarning(10511, "The request {RelayRequestId} timed out", request.RequestId);
 			return request.CreateResponse<TResponse>(HttpStatusCode.GatewayTimeout);
 		}
 		catch (Exception ex)
 		{
-			_logger.LogError(10512, ex, "An error occured while processing request {RequestId} {@Request}",
+			_logger.LogError(10512, ex,
+				"An error occured while processing request {RelayRequestId} {@Request}",
 				request.RequestId,
 				request);
 			return request.CreateResponse<TResponse>(HttpStatusCode.BadGateway);

--- a/src/Thinktecture.Relay.Connector/Targets/RelayWebTarget.cs
+++ b/src/Thinktecture.Relay.Connector/Targets/RelayWebTarget.cs
@@ -70,11 +70,11 @@ public partial class RelayWebTarget<TRequest, TResponse> : IRelayTarget<TRequest
 	public void Dispose()
 		=> HttpClient.Dispose();
 
-	[LoggerMessage(10700, LogLevel.Trace, "Requesting target for request {RequestId} at {BaseAddress} for {Url}")]
-	partial void LogRequestingTarget(Guid requestId, Uri? baseAddress, string url);
+	[LoggerMessage(10700, LogLevel.Trace, "Requesting target for request {RelayRequestId} at {BaseAddress} for {Url}")]
+	partial void LogRequestingTarget(Guid relayRequestId, Uri? baseAddress, string url);
 
-	[LoggerMessage(10701, LogLevel.Debug, "Requested target for request {RequestId} returned {HttpStatusCode}")]
-	partial void LogRequestedTarget(Guid requestId, HttpStatusCode httpStatusCode);
+	[LoggerMessage(10701, LogLevel.Debug, "Requested target for request {RelayRequestId} returned {HttpStatusCode}")]
+	partial void LogRequestedTarget(Guid relayRequestId, HttpStatusCode httpStatusCode);
 
 	/// <inheritdoc/>
 	public virtual async Task<TResponse> HandleAsync(TRequest request, CancellationToken cancellationToken = default)

--- a/src/Thinktecture.Relay.Server.Abstractions/Transport/ConnectorRegistry.cs
+++ b/src/Thinktecture.Relay.Server.Abstractions/Transport/ConnectorRegistry.cs
@@ -94,8 +94,8 @@ public partial class ConnectorRegistry<T>
 		registration?.Dispose();
 	}
 
-	[LoggerMessage(22103, LogLevel.Warning, "Unknown connection {ConnectionId} to transport request {RequestId} to")]
-	partial void LogUnknownRequestConnection(string connectionId, Guid requestId);
+	[LoggerMessage(22103, LogLevel.Warning, "Unknown connection {ConnectionId} to transport request {RelayRequestId} to")]
+	partial void LogUnknownRequestConnection(string connectionId, Guid relayRequestId);
 
 	/// <summary>
 	/// Transports a client request.
@@ -141,8 +141,8 @@ public partial class ConnectorRegistry<T>
 		return Task.CompletedTask;
 	}
 
-	[LoggerMessage(22105, LogLevel.Trace, "Delivering request {RequestId} to local connection {ConnectionId}")]
-	partial void LogDeliveringRequest(Guid requestId, string? connectionId);
+	[LoggerMessage(22105, LogLevel.Trace, "Delivering request {RelayRequestId} to local connection {ConnectionId}")]
+	partial void LogDeliveringRequest(Guid relayRequestId, string? connectionId);
 
 	/// <summary>
 	/// Tries to deliver the client request to a random connector.

--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore/RequestService.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore/RequestService.cs
@@ -45,7 +45,9 @@ public class RequestService : IRequestService
 		}
 		catch (Exception ex)
 		{
-			_logger.LogError(23101, ex, "An error occured while storing request {RequestId}", request.RequestId);
+			_logger.LogError(23101, ex,
+				"An error occured while storing request {RelayRequestId}",
+				request.RequestId);
 		}
 	}
 }

--- a/src/Thinktecture.Relay.Server.Protocols.RabbitMq/ServerTransport.cs
+++ b/src/Thinktecture.Relay.Server.Protocols.RabbitMq/ServerTransport.cs
@@ -102,15 +102,15 @@ public partial class ServerTransport<TResponse, TAcknowledge> : IServerTransport
 		LogDispatchedAcknowledge(request.RequestId, request.OriginId);
 	}
 
-	[LoggerMessage(25200, LogLevel.Trace, "Dispatched response for request {RequestId} to origin {OriginId}")]
-	partial void LogDispatchedResponse(Guid requestId, Guid originId);
+	[LoggerMessage(25200, LogLevel.Trace, "Dispatched response for request {RelayRequestId} to origin {OriginId}")]
+	partial void LogDispatchedResponse(Guid relayRequestId, Guid originId);
 
-	[LoggerMessage(25201, LogLevel.Trace, "Dispatched acknowledgement for request {RequestId} to origin {OriginId}")]
-	partial void LogDispatchedAcknowledge(Guid requestId, Guid originId);
+	[LoggerMessage(25201, LogLevel.Trace, "Dispatched acknowledgement for request {RelayRequestId} to origin {OriginId}")]
+	partial void LogDispatchedAcknowledge(Guid relayRequestId, Guid originId);
 
 	[LoggerMessage(25202, LogLevel.Trace,
-		"Received response for request {RequestId} from queue {QueueName} by consumer {ConsumerTag}")]
-	partial void LogResponseConsumed(Guid requestId, string queueName, string consumerTag);
+		"Received response for request {RelayRequestId} from queue {QueueName} by consumer {ConsumerTag}")]
+	partial void LogResponseConsumed(Guid relayRequestId, string queueName, string consumerTag);
 
 	private async Task ResponseConsumerReceived(object sender, BasicDeliverEventArgs @event)
 	{
@@ -122,8 +122,8 @@ public partial class ServerTransport<TResponse, TAcknowledge> : IServerTransport
 
 
 	[LoggerMessage(25203, LogLevel.Trace,
-		"Received acknowledge for request {RequestId} from queue {QueueName} by consumer {ConsumerTag}")]
-	partial void LogAcknowledgeConsumed(Guid requestId, string queueName, string consumerTag);
+		"Received acknowledge for request {RelayRequestId} from queue {QueueName} by consumer {ConsumerTag}")]
+	partial void LogAcknowledgeConsumed(Guid relayRequestId, string queueName, string consumerTag);
 
 	private async Task AcknowledgeConsumerReceived(object sender, BasicDeliverEventArgs @event)
 	{

--- a/src/Thinktecture.Relay.Server.Protocols.RabbitMq/TenantHandler.cs
+++ b/src/Thinktecture.Relay.Server.Protocols.RabbitMq/TenantHandler.cs
@@ -83,8 +83,8 @@ public partial class TenantHandler<TRequest, TAcknowledge> : ITenantHandler, IDi
 	}
 
 	[LoggerMessage(25302, LogLevel.Trace,
-		"Received request {RequestId} from queue {QueueName} by consumer {ConsumerTag}")]
-	partial void LogReceivedRequest(Guid requestId, string queueName, string consumerTag);
+		"Received request {RelayRequestId} from queue {QueueName} by consumer {ConsumerTag}")]
+	partial void LogReceivedRequest(Guid relayRequestId, string queueName, string consumerTag);
 
 	private async Task ConsumerReceived(object sender, BasicDeliverEventArgs @event)
 	{

--- a/src/Thinktecture.Relay.Server.Protocols.RabbitMq/TenantTransport.cs
+++ b/src/Thinktecture.Relay.Server.Protocols.RabbitMq/TenantTransport.cs
@@ -38,8 +38,8 @@ public partial class TenantTransport<T> : ITenantTransport<T>, IDisposable
 		_model = modelFactory.Create("tenant dispatcher");
 	}
 
-	[LoggerMessage(25400, LogLevel.Trace, "Published request {RequestId} to tenant {TenantId}")]
-	partial void LogPublishedRequest(Guid requestId, Guid tenantId);
+	[LoggerMessage(25400, LogLevel.Trace, "Published request {RelayRequestId} to tenant {TenantId}")]
+	partial void LogPublishedRequest(Guid relayRequestId, Guid tenantId);
 
 	/// <inheritdoc/>
 	public async Task TransportAsync(T request)
@@ -52,7 +52,7 @@ public partial class TenantTransport<T> : ITenantTransport<T>, IDisposable
 		catch (RabbitMQClientException ex)
 		{
 			_logger.LogError(25401, ex,
-				"An error occured while dispatching request {RequestId} to tenant {TenantId} queue",
+				"An error occured while dispatching request {RelayRequestId} to tenant {TenantId} queue",
 				request.RequestId, request.TenantId);
 			throw new TransportException(ex);
 		}

--- a/src/Thinktecture.Relay.Server.Protocols.SignalR/ConnectorHub.cs
+++ b/src/Thinktecture.Relay.Server.Protocols.SignalR/ConnectorHub.cs
@@ -118,8 +118,8 @@ public partial class ConnectorHub<TRequest, TResponse, TAcknowledge> : Hub<IConn
 		await base.OnDisconnectedAsync(exception);
 	}
 
-	[LoggerMessage(26104, LogLevel.Debug, "Connection {ConnectionId} received response for request {RequestId}")]
-	partial void LogReceivedResponse(string connectionId, Guid requestId);
+	[LoggerMessage(26104, LogLevel.Debug, "Connection {ConnectionId} received response for request {RelayRequestId}")]
+	partial void LogReceivedResponse(string connectionId, Guid relayRequestId);
 
 	/// <summary>
 	/// Hub method.
@@ -137,8 +137,8 @@ public partial class ConnectorHub<TRequest, TResponse, TAcknowledge> : Hub<IConn
 		await _connectionStatisticsWriter.UpdateLastActivityTimeAsync(Context.ConnectionId);
 	}
 
-	[LoggerMessage(26105, LogLevel.Debug, "Connection {ConnectionId} received acknowledgement for request {RequestId}")]
-	partial void LogReceivedAcknowledge(string connectionId, Guid requestId);
+	[LoggerMessage(26105, LogLevel.Debug, "Connection {ConnectionId} received acknowledgement for request {RelayRequestId}")]
+	partial void LogReceivedAcknowledge(string connectionId, Guid relayRequestId);
 
 	/// <summary>
 	/// Hub method.

--- a/src/Thinktecture.Relay.Server.Protocols.SignalR/ConnectorTransport.cs
+++ b/src/Thinktecture.Relay.Server.Protocols.SignalR/ConnectorTransport.cs
@@ -22,7 +22,7 @@ public class ConnectorTransport<TRequest, TResponse, TAcknowledge> : IConnectorT
 
 	private readonly Action<ILogger, IClientRequest, Guid, string, Exception?> _logTransportingRequest =
 		LoggerMessage.Define<IClientRequest, Guid, string>(LogLevel.Trace, 26200,
-			"Transporting request {@Request} for request {RequestId} on connection {ConnectionId}");
+			"Transporting request {@Request} for request {RelayRequestId} on connection {ConnectionId}");
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ConnectorTransport{TRequest,TResponse,TAcknowledge}"/> class.
@@ -51,7 +51,7 @@ public class ConnectorTransport<TRequest, TResponse, TAcknowledge> : IConnectorT
 		catch (Exception ex)
 		{
 			_logger.LogError(26201, ex,
-				"An error occured while transporting request {RequestId} on connection {ConnectionId}",
+				"An error occured while transporting request {RelayRequestId} on connection {ConnectionId}",
 				request.RequestId,
 				_connectionId);
 		}

--- a/src/Thinktecture.Relay.Server/Controllers/AcknowledgeController.cs
+++ b/src/Thinktecture.Relay.Server/Controllers/AcknowledgeController.cs
@@ -21,8 +21,8 @@ public partial class AcknowledgeController : Controller
 	public AcknowledgeController(ILogger<AcknowledgeController> logger)
 		=> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-	[LoggerMessage(20100, LogLevel.Debug, "Received acknowledgement for request {RequestId} on origin {OriginId}")]
-	partial void LogAcknowledgementReceived(Guid originId, Guid requestId);
+	[LoggerMessage(20100, LogLevel.Debug, "Received acknowledgement for request {RelayRequestId} on origin {OriginId}")]
+	partial void LogAcknowledgementReceived(Guid originId, Guid relayRequestId);
 
 	/// <summary>
 	/// </summary>

--- a/src/Thinktecture.Relay.Server/Controllers/BodyContentController.cs
+++ b/src/Thinktecture.Relay.Server/Controllers/BodyContentController.cs
@@ -24,8 +24,8 @@ public partial class BodyContentController : Controller
 		=> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
 	[LoggerMessage(20200, LogLevel.Debug,
-		"Delivering request body content for request {RequestId}, should delete: {DeleteBody}")]
-	partial void LogDeliverBody(Guid requestId, bool deleteBody);
+		"Delivering request body content for request {RelayRequestId}, should delete: {DeleteBody}")]
+	partial void LogDeliverBody(Guid relayRequestId, bool deleteBody);
 
 	/// <summary>
 	/// Streams the body content of the request.
@@ -53,8 +53,8 @@ public partial class BodyContentController : Controller
 		return new FileStreamResult(stream, MediaTypeNames.Application.Octet);
 	}
 
-	[LoggerMessage(20201, LogLevel.Debug, "Storing response body content for request {RequestId}")]
-	partial void LogStoreBody(Guid requestId);
+	[LoggerMessage(20201, LogLevel.Debug, "Storing response body content for request {RelayRequestId}")]
+	partial void LogStoreBody(Guid relayRequestId);
 
 	/// <summary>
 	/// Stores the body content of the response.
@@ -76,7 +76,7 @@ public partial class BodyContentController : Controller
 		}
 		catch (OperationCanceledException)
 		{
-			_logger.LogWarning(20202, "Connector for {TenantId} aborted the response body upload for request {RequestId}",
+			_logger.LogWarning(20202, "Connector for {TenantId} aborted the response body upload for request {RelayRequestId}",
 				User.GetTenantInfo().Id, requestId);
 			return NoContent();
 		}

--- a/src/Thinktecture.Relay.Server/Diagnostics/RelayRequestLogger.cs
+++ b/src/Thinktecture.Relay.Server/Diagnostics/RelayRequestLogger.cs
@@ -35,8 +35,8 @@ public partial class RelayRequestLogger<TRequest, TResponse> : IRelayRequestLogg
 		_relayServerOptions = relayServerOptions.Value;
 	}
 
-	[LoggerMessage(20400, LogLevel.Trace, "Writing request log for successful request {RequestId}")]
-	partial void LogSuccess(Guid requestId);
+	[LoggerMessage(20400, LogLevel.Trace, "Writing request log for successful request {RelayRequestId}")]
+	partial void LogSuccess(Guid relayRequestId);
 
 	/// <inheritdoc/>
 	public async Task LogSuccessAsync(IRelayContext<TRequest, TResponse> relayContext)
@@ -51,8 +51,8 @@ public partial class RelayRequestLogger<TRequest, TResponse> : IRelayRequestLogg
 		await _requestService.StoreRequestAsync(request);
 	}
 
-	[LoggerMessage(20401, LogLevel.Trace, "Writing request log for aborted request {RequestId}")]
-	partial void LogAbort(Guid requestId);
+	[LoggerMessage(20401, LogLevel.Trace, "Writing request log for aborted request {RelayRequestId}")]
+	partial void LogAbort(Guid relayRequestId);
 
 	/// <inheritdoc/>
 	public async Task LogAbortAsync(IRelayContext<TRequest, TResponse> relayContext)
@@ -66,8 +66,8 @@ public partial class RelayRequestLogger<TRequest, TResponse> : IRelayRequestLogg
 		await _requestService.StoreRequestAsync(request);
 	}
 
-	[LoggerMessage(20402, LogLevel.Trace, "Writing request log for failed request {RequestId}")]
-	partial void LogFail(Guid requestId);
+	[LoggerMessage(20402, LogLevel.Trace, "Writing request log for failed request {RelayRequestId}")]
+	partial void LogFail(Guid relayRequestId);
 
 	/// <inheritdoc/>
 	public async Task LogFailAsync(IRelayContext<TRequest, TResponse> relayContext)
@@ -81,8 +81,8 @@ public partial class RelayRequestLogger<TRequest, TResponse> : IRelayRequestLogg
 		await _requestService.StoreRequestAsync(request);
 	}
 
-	[LoggerMessage(20403, LogLevel.Trace, "Writing request log for expired request {RequestId}")]
-	partial void LogExpired(Guid requestId);
+	[LoggerMessage(20403, LogLevel.Trace, "Writing request log for expired request {RelayRequestId}")]
+	partial void LogExpired(Guid relayRequestId);
 
 	/// <inheritdoc/>
 	public async Task LogExpiredAsync(IRelayContext<TRequest, TResponse> relayContext)
@@ -96,8 +96,8 @@ public partial class RelayRequestLogger<TRequest, TResponse> : IRelayRequestLogg
 		await _requestService.StoreRequestAsync(request);
 	}
 
-	[LoggerMessage(20404, LogLevel.Trace, "Writing request log for error on request {RequestId}")]
-	partial void LogError(Guid requestId);
+	[LoggerMessage(20404, LogLevel.Trace, "Writing request log for error on request {RelayRequestId}")]
+	partial void LogError(Guid relayRequestId);
 
 	/// <inheritdoc/>
 	public async Task LogErrorAsync(IRelayContext<TRequest, TResponse> relayContext)

--- a/src/Thinktecture.Relay.Server/Middleware/RelayMiddleware.cs
+++ b/src/Thinktecture.Relay.Server/Middleware/RelayMiddleware.cs
@@ -110,14 +110,14 @@ public partial class RelayMiddleware<TRequest, TResponse, TAcknowledge> : IMiddl
 	[LoggerMessage(20601, LogLevel.Information, "Unknown tenant {Tenant} in request received {Path}{Query}")]
 	partial void LogUnknownTenant(string tenant, string path, QueryString query);
 
-	[LoggerMessage(20603, LogLevel.Trace, "Received response for request {RequestId}")]
-	partial void LogResponseReceived(Guid requestId);
+	[LoggerMessage(20603, LogLevel.Trace, "Received response for request {RelayRequestId}")]
+	partial void LogResponseReceived(Guid relayRequestId);
 
-	[LoggerMessage(20604, LogLevel.Debug, "Client aborted request {RequestId}")]
-	partial void LogClientAborted(Guid requestId);
+	[LoggerMessage(20604, LogLevel.Debug, "Client aborted request {RelayRequestId}")]
+	partial void LogClientAborted(Guid relayRequestId);
 
-	[LoggerMessage(20605, LogLevel.Information, "Request {RequestId} expired")]
-	partial void LogRequestExpired(Guid requestId);
+	[LoggerMessage(20605, LogLevel.Information, "Request {RelayRequestId} expired")]
+	partial void LogRequestExpired(Guid relayRequestId);
 
 	/// <inheritdoc/>
 	public async Task InvokeAsync(HttpContext context, RequestDelegate next)
@@ -197,15 +197,15 @@ public partial class RelayMiddleware<TRequest, TResponse, TAcknowledge> : IMiddl
 		catch (Exception ex)
 		{
 			await _relayRequestLogger.LogErrorAsync(_relayContext);
-			_logger.LogError(20606, ex, "Could not handle request {RequestId}", _relayContext.RequestId);
+			_logger.LogError(20606, ex, "Could not handle request {RelayRequestId}", _relayContext.RequestId);
 		}
 	}
 
-	[LoggerMessage(20607, LogLevel.Debug, "Executing client request interceptors for request {RequestId}")]
-	partial void LogExecutingRequestInterceptors(Guid requestId);
+	[LoggerMessage(20607, LogLevel.Debug, "Executing client request interceptors for request {RelayRequestId}")]
+	partial void LogExecutingRequestInterceptors(Guid relayRequestId);
 
-	[LoggerMessage(20608, LogLevel.Trace, "Executing interceptor {Interceptor} for request {RequestId}")]
-	partial void LogExecutingRequestInterceptor(string? interceptor, Guid requestId);
+	[LoggerMessage(20608, LogLevel.Trace, "Executing interceptor {Interceptor} for request {RelayRequestId}")]
+	partial void LogExecutingRequestInterceptor(string? interceptor, Guid relayRequestId);
 
 	private async Task InterceptClientRequestAsync(CancellationToken cancellationToken)
 	{
@@ -227,8 +227,8 @@ public partial class RelayMiddleware<TRequest, TResponse, TAcknowledge> : IMiddl
 		}
 	}
 
-	[LoggerMessage(20609, LogLevel.Trace, "Delivering request {RequestId} to connector")]
-	partial void LogDeliveringRequest(Guid requestId);
+	[LoggerMessage(20609, LogLevel.Trace, "Delivering request {RelayRequestId} to connector")]
+	partial void LogDeliveringRequest(Guid relayRequestId);
 
 	private async Task DeliverToConnectorAsync(CancellationToken cancellationToken)
 	{
@@ -246,8 +246,8 @@ public partial class RelayMiddleware<TRequest, TResponse, TAcknowledge> : IMiddl
 		await _requestCoordinator.ProcessRequestAsync(_relayContext.ClientRequest, cancellationToken);
 	}
 
-	[LoggerMessage(20610, LogLevel.Trace, "Waiting for connector response for request {RequestId}")]
-	partial void LogWaitForResponse(Guid requestId);
+	[LoggerMessage(20610, LogLevel.Trace, "Waiting for connector response for request {RelayRequestId}")]
+	partial void LogWaitForResponse(Guid relayRequestId);
 
 	private async Task WaitForConnectorResponseAsync(CancellationToken cancellationToken)
 	{
@@ -265,11 +265,11 @@ public partial class RelayMiddleware<TRequest, TResponse, TAcknowledge> : IMiddl
 	}
 
 
-	[LoggerMessage(20611, LogLevel.Debug, "Executing target response interceptors for request {RequestId}")]
-	partial void LogExecutingResponseInterceptors(Guid requestId);
+	[LoggerMessage(20611, LogLevel.Debug, "Executing target response interceptors for request {RelayRequestId}")]
+	partial void LogExecutingResponseInterceptors(Guid relayRequestId);
 
-	[LoggerMessage(20612, LogLevel.Trace, "Executing interceptor {Interceptor} for request {RequestId}")]
-	partial void LogExecutingResponseInterceptor(string? interceptor, Guid? requestId);
+	[LoggerMessage(20612, LogLevel.Trace, "Executing interceptor {Interceptor} for request {RelayRequestId}")]
+	partial void LogExecutingResponseInterceptor(string? interceptor, Guid? relayRequestId);
 
 	private async Task InterceptTargetResponseAsync(CancellationToken cancellationToken)
 	{
@@ -283,14 +283,14 @@ public partial class RelayMiddleware<TRequest, TResponse, TAcknowledge> : IMiddl
 	}
 
 	[LoggerMessage(20613, LogLevel.Debug,
-		"Outsourcing from request {BodySize} bytes because of a maximum of {BinarySizeThreshold} for request {RequestId}")]
-	partial void LogOutsourcingRequestBody(long? bodySize, int binarySizeThreshold, Guid requestId);
+		"Outsourcing from request {BodySize} bytes because of a maximum of {BinarySizeThreshold} for request {RelayRequestId}")]
+	partial void LogOutsourcingRequestBody(long? bodySize, int binarySizeThreshold, Guid relayRequestId);
 
-	[LoggerMessage(20614, LogLevel.Trace, "Outsourced from request {BodySize} bytes for request {RequestId}")]
-	partial void LogOutsourcedRequestBody(long? bodySize, Guid requestId);
+	[LoggerMessage(20614, LogLevel.Trace, "Outsourced from request {BodySize} bytes for request {RelayRequestId}")]
+	partial void LogOutsourcedRequestBody(long? bodySize, Guid relayRequestId);
 
-	[LoggerMessage(20615, LogLevel.Debug, "Inlined from request {BodySize} bytes for request {RequestId}")]
-	partial void LogInlinedRequestBody(long? bodySize, Guid requestId);
+	[LoggerMessage(20615, LogLevel.Debug, "Inlined from request {BodySize} bytes for request {RelayRequestId}")]
+	partial void LogInlinedRequestBody(long? bodySize, Guid relayRequestId);
 
 	private async Task<bool> TryInlineBodyContentAsync(TRequest request, CancellationToken cancellationToken)
 	{

--- a/src/Thinktecture.Relay.Server/Services/RelayTargetResponseWriter.cs
+++ b/src/Thinktecture.Relay.Server/Services/RelayTargetResponseWriter.cs
@@ -24,8 +24,8 @@ public partial class RelayTargetResponseWriter<TResponse> : IRelayTargetResponse
 		=> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
 
-	[LoggerMessage(20700, LogLevel.Warning, "The request {RequestId} failed internally with {HttpStatusCode}")]
-	partial void LogFailedRequest(Guid requestId, HttpStatusCode httpStatusCode);
+	[LoggerMessage(20700, LogLevel.Warning, "The request {RelayRequestId} failed internally with {HttpStatusCode}")]
+	partial void LogFailedRequest(Guid relayRequestId, HttpStatusCode httpStatusCode);
 
 	/// <inheritdoc/>
 	public async Task WriteAsync(TResponse? targetResponse, HttpResponse httpResponse,

--- a/src/Thinktecture.Relay.Server/Transport/AcknowledgeCoordinator.cs
+++ b/src/Thinktecture.Relay.Server/Transport/AcknowledgeCoordinator.cs
@@ -35,8 +35,8 @@ public partial class AcknowledgeCoordinator<TRequest, TAcknowledge> : IAcknowled
 	}
 
 	[LoggerMessage(20800, LogLevel.Trace,
-		"Registering acknowledge state of request {RequestId} from connection {ConnectionId} for id {AcknowledgeId}")]
-	partial void LogRegisterAcknowledgeState(Guid requestId, string connectionId, string acknowledgeId);
+		"Registering acknowledge state of request {RelayRequestId} from connection {ConnectionId} for id {AcknowledgeId}")]
+	partial void LogRegisterAcknowledgeState(Guid relayRequestId, string connectionId, string acknowledgeId);
 
 	/// <inheritdoc/>
 	public void RegisterRequest(Guid requestId, string connectionId, string acknowledgeId,
@@ -46,8 +46,8 @@ public partial class AcknowledgeCoordinator<TRequest, TAcknowledge> : IAcknowled
 		_requests[requestId] = new AcknowledgeState(connectionId, acknowledgeId, outsourcedRequestBodyContent);
 	}
 
-	[LoggerMessage(20801, LogLevel.Warning, "Unknown request {RequestId} to acknowledge received")]
-	partial void LogUnknownRequest(Guid requestId);
+	[LoggerMessage(20801, LogLevel.Warning, "Unknown request {RelayRequestId} to acknowledge received")]
+	partial void LogUnknownRequest(Guid relayRequestId);
 
 	/// <inheritdoc/>
 	public async Task ProcessAcknowledgeAsync(TAcknowledge request, CancellationToken cancellationToken = default)

--- a/src/Thinktecture.Relay.Server/Transport/AcknowledgeDispatcher.cs
+++ b/src/Thinktecture.Relay.Server/Transport/AcknowledgeDispatcher.cs
@@ -42,12 +42,12 @@ public partial class AcknowledgeDispatcher<TResponse, TAcknowledge> : IAcknowled
 		_relayServerOptions = relayServerOptions.Value;
 	}
 
-	[LoggerMessage(20900, LogLevel.Trace, "Locally dispatching acknowledge for request {RequestId}")]
-	partial void LogLocalAcknowledge(Guid requestId);
+	[LoggerMessage(20900, LogLevel.Trace, "Locally dispatching acknowledge for request {RelayRequestId}")]
+	partial void LogLocalAcknowledge(Guid relayRequestId);
 
 	[LoggerMessage(20901, LogLevel.Trace,
-		"Remotely dispatching acknowledge for request {RequestId} to origin {OriginId}")]
-	partial void LogRedirectAcknowledge(Guid requestId, Guid originId);
+		"Remotely dispatching acknowledge for request {RelayRequestId} to origin {OriginId}")]
+	partial void LogRedirectAcknowledge(Guid relayRequestId, Guid originId);
 
 	/// <inheritdoc/>
 	public async Task DispatchAsync(TAcknowledge request, CancellationToken cancellationToken = default)

--- a/src/Thinktecture.Relay.Server/Transport/FileBodyStore.cs
+++ b/src/Thinktecture.Relay.Server/Transport/FileBodyStore.cs
@@ -28,16 +28,16 @@ internal partial class FileBodyStore : IBodyStore
 			_basePath);
 	}
 
-	[LoggerMessage(21001, LogLevel.Trace, "{FileOperation} {FileBodyType} body for request {RequestId}")]
-	partial void LogOperation(string fileOperation, string fileBodyType, Guid requestId);
+	[LoggerMessage(21001, LogLevel.Trace, "{FileOperation} {FileBodyType} body for request {RelayRequestId}")]
+	partial void LogOperation(string fileOperation, string fileBodyType, Guid relayRequestId);
 
 	[LoggerMessage(21002, LogLevel.Debug,
-		"Writing of {FileBodyType} body for request {RequestId} completed with {BodySize} bytes")]
-	partial void LogWriting(string fileBodyType, Guid requestId, long bodySize);
+		"Writing of {FileBodyType} body for request {RelayRequestId} completed with {BodySize} bytes")]
+	partial void LogWriting(string fileBodyType, Guid relayRequestId, long bodySize);
 
 	[LoggerMessage(21003, LogLevel.Warning,
-		"An error occured while {FileOperation} {FileBodyType} body for request {RequestId}")]
-	partial void LogError(Exception ex, string fileOperation, string fileBodyType, Guid requestId);
+		"An error occured while {FileOperation} {FileBodyType} body for request {RelayRequestId}")]
+	partial void LogError(Exception ex, string fileOperation, string fileBodyType, Guid relayRequestId);
 
 	/// <inheritdoc/>
 	public async Task<long> StoreRequestBodyAsync(Guid requestId, Stream bodyStream,

--- a/src/Thinktecture.Relay.Server/Transport/InMemoryTenantTransport.cs
+++ b/src/Thinktecture.Relay.Server/Transport/InMemoryTenantTransport.cs
@@ -23,7 +23,7 @@ internal class InMemoryTenantTransport<T> : ITenantTransport<T>
 	{
 		if (!await _connectorRegistry.TryDeliverRequestAsync(request))
 		{
-			_logger.LogError(21200, "Could not deliver request {RequestId} to a connection", request.RequestId);
+			_logger.LogError(21200, "Could not deliver request {RelayRequestId} to a connection", request.RequestId);
 		}
 	}
 }

--- a/src/Thinktecture.Relay.Server/Transport/RequestCoordinator.cs
+++ b/src/Thinktecture.Relay.Server/Transport/RequestCoordinator.cs
@@ -24,8 +24,8 @@ public partial class RequestCoordinator<T> : IRequestCoordinator<T>
 		_tenantTransport = tenantTransport ?? throw new ArgumentNullException(nameof(tenantTransport));
 	}
 
-	[LoggerMessage(21300, LogLevel.Debug, "Redirecting request {RequestId} to transport for tenant {TenantId}")]
-	partial void LogRedirect(Guid requestId, Guid tenantId);
+	[LoggerMessage(21300, LogLevel.Debug, "Redirecting request {RelayRequestId} to transport for tenant {TenantId}")]
+	partial void LogRedirect(Guid relayRequestId, Guid tenantId);
 
 	/// <inheritdoc/>
 	public async Task ProcessRequestAsync(T request, CancellationToken cancellationToken = default)

--- a/src/Thinktecture.Relay.Server/Transport/ResponseDispatcher.cs
+++ b/src/Thinktecture.Relay.Server/Transport/ResponseDispatcher.cs
@@ -41,11 +41,11 @@ public partial class ResponseDispatcher<TResponse, TAcknowledge> : IResponseDisp
 		_relayServerOptions = relayServerOptions.Value;
 	}
 
-	[LoggerMessage(21500, LogLevel.Trace, "Locally dispatching response for request {RequestId}")]
-	partial void LogLocalDispatch(Guid requestId);
+	[LoggerMessage(21500, LogLevel.Trace, "Locally dispatching response for request {RelayRequestId}")]
+	partial void LogLocalDispatch(Guid relayRequestId);
 
-	[LoggerMessage(21501, LogLevel.Trace, "Remotely dispatching response for request {RequestId} to origin {OriginId}")]
-	partial void LogRedirectDispatch(Guid requestId, Guid originId);
+	[LoggerMessage(21501, LogLevel.Trace, "Remotely dispatching response for request {RelayRequestId} to origin {OriginId}")]
+	partial void LogRedirectDispatch(Guid relayRequestId, Guid originId);
 
 	/// <inheritdoc/>
 	public async Task DispatchAsync(TResponse response, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Rename all logging placeholder names from RequestId to RelayRequestId to not interfere with
Fixes #401 