### PR TITLE
Fix overwritten connectionid 

### DIFF
--- a/src/Thinktecture.Relay.Connector.Protocols.SignalR/AcknowledgeTransport.cs
+++ b/src/Thinktecture.Relay.Connector.Protocols.SignalR/AcknowledgeTransport.cs
@@ -19,7 +19,7 @@ public class AcknowledgeTransport<T> : IAcknowledgeTransport<T>
 	// (see https://github.com/dotnet/runtime/issues/69490)
 	private readonly Action<ILogger, IAcknowledgeRequest, Guid, string?, Exception?> _logTransportingAck =
 		LoggerMessage.Define<IAcknowledgeRequest, Guid, string?>(LogLevel.Trace, 11100,
-			"Transporting acknowledge request {@AcknowledgeRequest} for request {RelayRequestId} on connection {ConnectionId}");
+			"Transporting acknowledge request {@AcknowledgeRequest} for request {RelayRequestId} on connection {TransportConnectionId}");
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="AcknowledgeTransport{T}"/> class.
@@ -45,7 +45,7 @@ public class AcknowledgeTransport<T> : IAcknowledgeTransport<T>
 		catch (Exception ex)
 		{
 			_logger.LogError(11101, ex,
-				"An error occured while transporting acknowledge for request {RelayRequestId} on connection {ConnectionId}",
+				"An error occured while transporting acknowledge for request {RelayRequestId} on connection {TransportConnectionId}",
 				request.RequestId, _hubConnection.ConnectionId);
 		}
 	}

--- a/src/Thinktecture.Relay.Connector.Protocols.SignalR/ResponseTransport.cs
+++ b/src/Thinktecture.Relay.Connector.Protocols.SignalR/ResponseTransport.cs
@@ -19,7 +19,7 @@ public class ResponseTransport<T> : IResponseTransport<T>
 	// (see https://github.com/dotnet/runtime/issues/69490)
 	private readonly Action<ILogger, ITargetResponse, Guid, string?, Exception?> _logTransportingResponse =
 		LoggerMessage.Define<ITargetResponse, Guid, string?>(LogLevel.Trace, 11500,
-			"Transporting response {@Response} for request {RelayRequestId} on connection {ConnectionId}");
+			"Transporting response {@Response} for request {RelayRequestId} on connection {TransportConnectionId}");
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ResponseTransport{T}"/> class.
@@ -44,7 +44,7 @@ public class ResponseTransport<T> : IResponseTransport<T>
 		catch (Exception ex)
 		{
 			_logger.LogError(11501, ex,
-				"An error occured while transporting response for request {RelayRequestId} on connection {ConnectionId}",
+				"An error occured while transporting response for request {RelayRequestId} on connection {TransportConnectionId}",
 				response.RequestId, _hubConnection.ConnectionId);
 		}
 	}

--- a/src/Thinktecture.Relay.Server.Abstractions/Transport/ConnectorRegistry.cs
+++ b/src/Thinktecture.Relay.Server.Abstractions/Transport/ConnectorRegistry.cs
@@ -55,7 +55,9 @@ public partial class ConnectorRegistry<T>
 	/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
 	public async Task RegisterAsync(string connectionId, Guid tenantId, IPAddress? remoteIpAddress = null)
 	{
-		_logger.LogDebug(22100, "Registering connection {ConnectionId} for tenant {TenantId}", connectionId, tenantId);
+		_logger.LogDebug(22100,
+			"Registering connection {TransportConnectionId} for tenant {TenantId}",
+			connectionId, tenantId);
 
 		var registration =
 			ActivatorUtilities.CreateInstance<ConnectorRegistration>(_serviceProvider, tenantId, connectionId);
@@ -80,13 +82,13 @@ public partial class ConnectorRegistry<T>
 		if (_registrations.TryRemove(connectionId, out var registration) &&
 		    _tenants.TryGetValue(registration.TenantId, out var connectors))
 		{
-			_logger.LogDebug(22101, "Unregistering connection {ConnectionId} for tenant {TenantId}", connectionId,
-				registration.TenantId);
+			_logger.LogDebug(22101, "Unregistering connection {TransportConnectionId} for tenant {TenantId}",
+				connectionId, registration.TenantId);
 			connectors.TryRemove(connectionId, out _);
 		}
 		else
 		{
-			_logger.LogWarning(22102, "Could not unregister connection {ConnectionId}", connectionId);
+			_logger.LogWarning(22102, "Could not unregister connection {TransportConnectionId}", connectionId);
 		}
 
 		await _connectionStatisticsWriter.SetDisconnectTimeAsync(connectionId);
@@ -94,8 +96,8 @@ public partial class ConnectorRegistry<T>
 		registration?.Dispose();
 	}
 
-	[LoggerMessage(22103, LogLevel.Warning, "Unknown connection {ConnectionId} to transport request {RelayRequestId} to")]
-	partial void LogUnknownRequestConnection(string connectionId, Guid relayRequestId);
+	[LoggerMessage(22103, LogLevel.Warning, "Unknown connection {TransportConnectionId} to transport request {RelayRequestId} to")]
+	partial void LogUnknownRequestConnection(string transportConnectionId, Guid relayRequestId);
 
 	/// <summary>
 	/// Transports a client request.
@@ -118,8 +120,8 @@ public partial class ConnectorRegistry<T>
 	}
 
 	[LoggerMessage(22104, LogLevel.Warning,
-		"Unknown connection {ConnectionId} to transport acknowledge {AcknowledgeId} to")]
-	partial void LogUnknownAcknowledgeConnection(string connectionId, string acknowledgeId);
+		"Unknown connection {TransportConnectionId} to transport acknowledge {AcknowledgeId} to")]
+	partial void LogUnknownAcknowledgeConnection(string transportConnectionId, string acknowledgeId);
 
 	/// <summary>
 	/// Acknowledges a client request.
@@ -141,8 +143,8 @@ public partial class ConnectorRegistry<T>
 		return Task.CompletedTask;
 	}
 
-	[LoggerMessage(22105, LogLevel.Trace, "Delivering request {RelayRequestId} to local connection {ConnectionId}")]
-	partial void LogDeliveringRequest(Guid relayRequestId, string? connectionId);
+	[LoggerMessage(22105, LogLevel.Trace, "Delivering request {RelayRequestId} to local connection {TransportConnectionId}")]
+	partial void LogDeliveringRequest(Guid relayRequestId, string? transportConnectionId);
 
 	/// <summary>
 	/// Tries to deliver the client request to a random connector.

--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore/StatisticsService.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore/StatisticsService.cs
@@ -134,7 +134,8 @@ public partial class StatisticsService : IStatisticsService
 		IPAddress? remoteIpAddress,
 		CancellationToken cancellationToken = default)
 	{
-		_logger.LogDebug(23308, "Adding new connection {ConnectionId} for statistics tracking", connectionId);
+		_logger.LogDebug(23308, "Adding new connection {TransportConnectionId} for statistics tracking",
+			connectionId);
 
 		try
 		{
@@ -156,14 +157,14 @@ public partial class StatisticsService : IStatisticsService
 		catch (Exception ex)
 		{
 			_logger.LogError(23309, ex,
-				"An error occured while creating connection {ConnectionId} for statistics tracking",
-				originId);
+				"An error occured while creating connection {TransportConnectionId} for statistics tracking",
+				connectionId);
 		}
 	}
 
 	[LoggerMessage(23310, LogLevel.Debug,
-		"Updating last activity time of connection {ConnectionId} in statistics tracking")]
-	partial void LogUpdateConnectionActivity(string connectionId);
+		"Updating last activity time of connection {TransportConnectionId} in statistics tracking")]
+	partial void LogUpdateConnectionActivity(string transportConnectionId);
 
 	/// <inheritdoc/>
 	public async Task UpdateLastActivityTimeAsync(string connectionId, CancellationToken cancellationToken = default)
@@ -183,7 +184,8 @@ public partial class StatisticsService : IStatisticsService
 		}
 		catch (Exception ex)
 		{
-			_logger.LogError(23311, ex, "An error occured while updating connection {ConnectionId} in statistics tracking",
+			_logger.LogError(23311, ex,
+				"An error occured while updating connection {TransportConnectionId} in statistics tracking",
 				connectionId);
 		}
 	}
@@ -191,7 +193,8 @@ public partial class StatisticsService : IStatisticsService
 	/// <inheritdoc/>
 	public async Task SetDisconnectTimeAsync(string connectionId, CancellationToken cancellationToken = default)
 	{
-		_logger.LogDebug(23312, "Setting disconnect time of connection {ConnectionId} in statistics tracking",
+		_logger.LogDebug(23312,
+			"Setting disconnect time of connection {TransportConnectionId} in statistics tracking",
 			connectionId);
 
 		try
@@ -207,7 +210,8 @@ public partial class StatisticsService : IStatisticsService
 		}
 		catch (Exception ex)
 		{
-			_logger.LogError(23313, ex, "An error occured while updating connection {ConnectionId} in statistics tracking",
+			_logger.LogError(23313, ex,
+				"An error occured while updating connection {TransportConnectionId} in statistics tracking",
 				connectionId);
 		}
 	}

--- a/src/Thinktecture.Relay.Server.Protocols.SignalR/ConnectorHub.cs
+++ b/src/Thinktecture.Relay.Server.Protocols.SignalR/ConnectorHub.cs
@@ -79,13 +79,16 @@ public partial class ConnectorHub<TRequest, TResponse, TAcknowledge> : Hub<IConn
 
 		if (tenant == null)
 		{
-			_logger.LogError(26100, "Rejecting incoming connection {ConnectionId} because of missing tenant info",
+			_logger.LogError(26100,
+				"Rejecting incoming connection {TransportConnectionId} because of missing tenant info",
 				Context.ConnectionId);
 			Context.Abort();
 			return;
 		}
 
-		_logger.LogDebug(26101, "Connection {ConnectionId} incoming for tenant {@Tenant}", Context.ConnectionId, tenant);
+		_logger.LogDebug(26101,
+			"Connection {TransportConnectionId} incoming for tenant {@Tenant}",
+			Context.ConnectionId, tenant);
 
 		await _connectorRegistry.RegisterAsync(Context.ConnectionId, tenant.Id,
 			Context.GetHttpContext()?.Connection.RemoteIpAddress);
@@ -104,13 +107,16 @@ public partial class ConnectorHub<TRequest, TResponse, TAcknowledge> : Hub<IConn
 	{
 		if (exception == null)
 		{
-			_logger.LogWarning(26102, exception, "Connection {ConnectionId} disconnected for tenant {@Tenant}",
+			_logger.LogWarning(26102, exception,
+				"Connection {TransportConnectionId} disconnected for tenant {@Tenant}",
 				Context.ConnectionId,
 				Context.User?.GetTenantInfo());
 		}
 		else
 		{
-			_logger.LogDebug(26103, "Connection {ConnectionId} disconnected for tenant {@Tenant}", Context.ConnectionId,
+			_logger.LogDebug(26103,
+				"Connection {TransportConnectionId} disconnected for tenant {@Tenant}",
+				Context.ConnectionId,
 				Context.User?.GetTenantInfo());
 		}
 
@@ -118,8 +124,8 @@ public partial class ConnectorHub<TRequest, TResponse, TAcknowledge> : Hub<IConn
 		await base.OnDisconnectedAsync(exception);
 	}
 
-	[LoggerMessage(26104, LogLevel.Debug, "Connection {ConnectionId} received response for request {RelayRequestId}")]
-	partial void LogReceivedResponse(string connectionId, Guid relayRequestId);
+	[LoggerMessage(26104, LogLevel.Debug, "Connection {TransportConnectionId} received response for request {RelayRequestId}")]
+	partial void LogReceivedResponse(string transportConnectionId, Guid relayRequestId);
 
 	/// <summary>
 	/// Hub method.
@@ -137,8 +143,8 @@ public partial class ConnectorHub<TRequest, TResponse, TAcknowledge> : Hub<IConn
 		await _connectionStatisticsWriter.UpdateLastActivityTimeAsync(Context.ConnectionId);
 	}
 
-	[LoggerMessage(26105, LogLevel.Debug, "Connection {ConnectionId} received acknowledgement for request {RelayRequestId}")]
-	partial void LogReceivedAcknowledge(string connectionId, Guid relayRequestId);
+	[LoggerMessage(26105, LogLevel.Debug, "Connection {TransportConnectionId} received acknowledgement for request {RelayRequestId}")]
+	partial void LogReceivedAcknowledge(string transportConnectionId, Guid relayRequestId);
 
 	/// <summary>
 	/// Hub method.

--- a/src/Thinktecture.Relay.Server.Protocols.SignalR/ConnectorTransport.cs
+++ b/src/Thinktecture.Relay.Server.Protocols.SignalR/ConnectorTransport.cs
@@ -22,7 +22,7 @@ public class ConnectorTransport<TRequest, TResponse, TAcknowledge> : IConnectorT
 
 	private readonly Action<ILogger, IClientRequest, Guid, string, Exception?> _logTransportingRequest =
 		LoggerMessage.Define<IClientRequest, Guid, string>(LogLevel.Trace, 26200,
-			"Transporting request {@Request} for request {RelayRequestId} on connection {ConnectionId}");
+			"Transporting request {@Request} for request {RelayRequestId} on connection {TransportConnectionId}");
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ConnectorTransport{TRequest,TResponse,TAcknowledge}"/> class.
@@ -51,7 +51,7 @@ public class ConnectorTransport<TRequest, TResponse, TAcknowledge> : IConnectorT
 		catch (Exception ex)
 		{
 			_logger.LogError(26201, ex,
-				"An error occured while transporting request {RelayRequestId} on connection {ConnectionId}",
+				"An error occured while transporting request {RelayRequestId} on connection {TransportConnectionId}",
 				request.RequestId,
 				_connectionId);
 		}

--- a/src/Thinktecture.Relay.Server/Transport/AcknowledgeCoordinator.cs
+++ b/src/Thinktecture.Relay.Server/Transport/AcknowledgeCoordinator.cs
@@ -35,8 +35,8 @@ public partial class AcknowledgeCoordinator<TRequest, TAcknowledge> : IAcknowled
 	}
 
 	[LoggerMessage(20800, LogLevel.Trace,
-		"Registering acknowledge state of request {RelayRequestId} from connection {ConnectionId} for id {AcknowledgeId}")]
-	partial void LogRegisterAcknowledgeState(Guid relayRequestId, string connectionId, string acknowledgeId);
+		"Registering acknowledge state of request {RelayRequestId} from connection {TransportConnectionId} for id {AcknowledgeId}")]
+	partial void LogRegisterAcknowledgeState(Guid relayRequestId, string transportConnectionId, string acknowledgeId);
 
 	/// <inheritdoc/>
 	public void RegisterRequest(Guid requestId, string connectionId, string acknowledgeId,


### PR DESCRIPTION
Fixes #403 

Will conflict with #402 
Will also conflict with #398 

After merging #402 and #398 this should be rebased and the few lines where RequestId and ConnectionId are used together need to be adjusted.
