### PR TITLE
Keep WWW-Authenticate header value from OPC

### DIFF
--- a/Documentation/de/relayserver.md
+++ b/Documentation/de/relayserver.md
@@ -7,6 +7,12 @@
 
 # Release Notes
 
+## Version 2.4.4
+
+* Fehlerbehebungen
+
+  * Ein vom On-Premise Connector gelieferter `WWW-Authenticate` Header wird nun unverändert weitergegeben.
+
 ## Version 2.4.3
 
 * Fehlerbehebungen

--- a/Documentation/en/relayserver.md
+++ b/Documentation/en/relayserver.md
@@ -17,6 +17,12 @@ The goal of this list is to highlight companies who pay back to this open source
 
 # Version history
 
+## Version 2.4.4
+
+* Bug fixes
+
+  * Fixed a bug where a `WWW-Authenticate` header from the OPC was modified before sending out.
+
 ## Version 2.4.3
 
 * Bug fixes

--- a/Shared/AssemblyInfo.shared.cs
+++ b/Shared/AssemblyInfo.shared.cs
@@ -4,9 +4,9 @@ using System.Reflection;
 
 [assembly: AssemblyCompany("Thinktecture AG")]
 [assembly: AssemblyProduct("Thinktecture RelayServer")]
-[assembly: AssemblyCopyright("Copyright © Thinktecture AG 2015 - 2022. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Thinktecture AG 2015 - 2023. All rights reserved.")]
 [assembly: AssemblyTrademark("Thinktecture RelayServer")]
 
-[assembly: AssemblyVersion("2.4.3.0")]
-[assembly: AssemblyFileVersion("2.4.3.0")]
-[assembly: AssemblyInformationalVersion("2.4.3.0")]
+[assembly: AssemblyVersion("2.4.4.0")]
+[assembly: AssemblyFileVersion("2.4.4.0")]
+[assembly: AssemblyInformationalVersion("2.4.4.0")]

--- a/Shared/ProjectProperties.shared.props
+++ b/Shared/ProjectProperties.shared.props
@@ -1,10 +1,10 @@
 <Project>
   <!-- WARNING: This file is shared between all RelayServer .NET Core library projects -->
   <PropertyGroup>
-    <VersionPrefix>2.4.3</VersionPrefix>
-    <PackageVersion>2.4.3</PackageVersion>
+    <VersionPrefix>2.4.4</VersionPrefix>
+    <PackageVersion>2.4.4</PackageVersion>
 
-    <Copyright>Copyright © Thinktecture AG 2015 - 2022. All rights reserved.</Copyright>
+    <Copyright>Copyright © Thinktecture AG 2015 - 2023. All rights reserved.</Copyright>
     <PackageTags>thinktecture;relayserver</PackageTags>
     <PackageIcon>Logo_T_Nontransparent.png</PackageIcon>
     <PackageProjectUrl>https://github.com/thinktecture/relayserver</PackageProjectUrl>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinktecture-relayserver",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "RelayServer",
   "main": "gulpfile.js",
   "repository": {


### PR DESCRIPTION
Hey there

A customer of mine (I am from CM Informatik AG) wanted to transition one of its apps from a RelayServer v1 to a RelayServer v2. In the process we discovered, that the WWW-Authenticate header was not returned from the RelayServer as it was sent from the OPC.

It looks like the special handling for the WWW-Authenticate header is only applied if `_configuration.OAuthCertificate` is not null or whitespace. In my opinion this special handling should always be applied, no matter if the `if` or the `else` path is taken.

I took the freedom to test it with the suggested changes and it worked. The old call to `UseJwtBearerAuthentication` is just a slim wrapper around `UseOAuthBearerAuthentication`.

~Patrick