### PR TITLE
http headers are to be treated case-insensitive

### DIFF
--- a/src/Thinktecture.Relay.Abstractions/Extensions/ClientRequestExtensions.cs
+++ b/src/Thinktecture.Relay.Abstractions/Extensions/ClientRequestExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net;
 using Thinktecture.Relay.Acknowledgement;
@@ -43,7 +44,7 @@ public static class ClientRequestExtensions
 		{
 			RequestId = request.RequestId,
 			RequestOriginId = request.RequestOriginId,
-			HttpHeaders = new Dictionary<string, string[]>(),
+			HttpHeaders = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase),
 		};
 
 		if (failureStatusCode == null) return response;

--- a/src/Thinktecture.Relay.Abstractions/Transport/ClientRequest.cs
+++ b/src/Thinktecture.Relay.Abstractions/Transport/ClientRequest.cs
@@ -34,7 +34,7 @@ public class ClientRequest : IClientRequest
 	public string Url { get; set; } = default!;
 
 	/// <inheritdoc/>
-	public IDictionary<string, string[]> HttpHeaders { get; set; } = default!;
+	public IDictionary<string, string[]> HttpHeaders { get; set; } = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
 
 	/// <inheritdoc/>
 	public long? BodySize { get; set; }

--- a/src/Thinktecture.Relay.Connector/Targets/ClientRequestHandler.cs
+++ b/src/Thinktecture.Relay.Connector/Targets/ClientRequestHandler.cs
@@ -120,7 +120,7 @@ public partial class ClientRequestHandler<TRequest, TResponse, TAcknowledge> : I
 
 		if (enableTracing)
 		{
-			response.HttpHeaders ??= new Dictionary<string, string[]>();
+			response.HttpHeaders ??= new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
 			response.HttpHeaders[Constants.HeaderNames.ConnectorMachineName] = new[] { Environment.MachineName };
 			response.HttpHeaders[Constants.HeaderNames.ConnectorVersion] = new[] { RelayConnector.AssemblyVersion };
 		}

--- a/src/Thinktecture.Relay.Connector/Targets/RelayWebTarget.cs
+++ b/src/Thinktecture.Relay.Connector/Targets/RelayWebTarget.cs
@@ -248,7 +248,7 @@ public static class HttpResponseMessageExtensions
 
 		response.HttpStatusCode = message.StatusCode;
 		response.HttpHeaders = message.Headers.Concat(message.Content.Headers)
-			.ToDictionary(h => h.Key, h => h.Value.ToArray());
+			.ToDictionary(h => h.Key, h => h.Value.ToArray(), StringComparer.OrdinalIgnoreCase);
 		response.BodySize = hasBody ? message.Content.Headers.ContentLength : 0;
 		response.BodyContent = hasBody ? await message.Content.ReadAsStreamAsync(CancellationToken.None) : null;
 

--- a/src/Thinktecture.Relay.Server/Transport/RelayClientRequestFactory.cs
+++ b/src/Thinktecture.Relay.Server/Transport/RelayClientRequestFactory.cs
@@ -43,7 +43,7 @@ public class RelayClientRequestFactory<T> : IRelayClientRequestFactory<T>
 			TenantId = tenantId,
 			HttpMethod = httpRequest.Method,
 			Url = $"{string.Join("/", parts.Skip(2))}{httpRequest.QueryString}",
-			HttpHeaders = httpRequest.Headers.ToDictionary(h => h.Key, h => h.Value.ToArray()),
+			HttpHeaders = httpRequest.Headers.ToDictionary(h => h.Key, h => h.Value.ToArray(), StringComparer.OrdinalIgnoreCase),
 			BodySize = httpRequest.Body.Length,
 			BodyContent = httpRequest.Body.Length == 0 ? null : httpRequest.Body,
 			AcknowledgeMode = _relayServerOptions.AcknowledgeMode,


### PR DESCRIPTION
Use a case-insensitive string comparer when creating the request / response dictionaries.

Fixes #422 