### PR TITLE
Fix failing SQL Server migrations

### DIFF
--- a/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer/Migrations/ConfigurationDb/20201124123541_Rename_Properties.cs
+++ b/src/Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer/Migrations/ConfigurationDb/20201124123541_Rename_Properties.cs
@@ -3,48 +3,70 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Thinktecture.Relay.Server.Persistence.EntityFrameworkCore.SqlServer.Migrations.ConfigurationDb
 {
-    public partial class Rename_Properties : Migration
-    {
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-	        migrationBuilder.RenameColumn(
-		        name: "HeartbeatTime",
-		        newName: "LastSeenTime",
-		        table: "Origins");
+	public partial class Rename_Properties : Migration
+	{
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.RenameColumn(
+				name: "HeartbeatTime",
+				newName: "LastSeenTime",
+				table: "Origins");
 
-	        migrationBuilder.RenameColumn(
-		        name: "StartTime",
-		        newName: "StartupTime",
-		        table: "Origins");
+			migrationBuilder.RenameColumn(
+				name: "StartTime",
+				newName: "StartupTime",
+				table: "Origins");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Id",
-                table: "Connections",
-                maxLength: 100,
-                nullable: false,
-                oldClrType: typeof(string),
-                oldType: "nvarchar(450)");
-        }
+			// manual insertion
+			migrationBuilder.DropPrimaryKey(
+				name: "PK_Connections",
+				table: "Connections");
 
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-	        migrationBuilder.RenameColumn(
-		        name: "LastSeenTime",
-		        newName: "HeartbeatTime",
-		        table: "Origins");
+			migrationBuilder.AlterColumn<string>(
+				name: "Id",
+				table: "Connections",
+				maxLength: 100,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "nvarchar(450)");
 
-	        migrationBuilder.RenameColumn(
-		        name: "StartupTime",
-		        newName: "StartTime",
-		        table: "Origins");
+			// manual insertion
+			migrationBuilder.AddPrimaryKey(
+				name: "PK_Connections",
+				table: "Connections",
+				column: "Id");
+		}
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Id",
-                table: "Connections",
-                type: "nvarchar(450)",
-                nullable: false,
-                oldClrType: typeof(string),
-                oldMaxLength: 100);
-        }
-    }
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.RenameColumn(
+				name: "LastSeenTime",
+				newName: "HeartbeatTime",
+				table: "Origins");
+
+			migrationBuilder.RenameColumn(
+				name: "StartupTime",
+				newName: "StartTime",
+				table: "Origins");
+
+			// manual insertion
+			migrationBuilder.DropPrimaryKey(
+				name: "PK_Connections",
+				table: "Connections");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "Id",
+				table: "Connections",
+				type: "nvarchar(450)",
+				nullable: false,
+				oldClrType: typeof(string),
+				oldMaxLength: 100);
+
+			// manual insertion
+			migrationBuilder.AddPrimaryKey(
+				name: "PK_Connections",
+				table: "Connections",
+				column: "Id");
+		}
+	}
 }


### PR DESCRIPTION
SQL server migrations fail, because a columns max length is changed which has a PK on it.
PR drops PK before changing column length, then re-adds PK.

Fixes #421