### PR TITLE
fix(management): add persistence mapping of missing fields

### DIFF
--- a/src/Thinktecture.Relay.Server.Abstractions/Persistence/Models/PersistenceModelExtensions.cs
+++ b/src/Thinktecture.Relay.Server.Abstractions/Persistence/Models/PersistenceModelExtensions.cs
@@ -51,6 +51,8 @@ public static class PersistenceModelsExtensions
 
 		instance.DisplayName = other.DisplayName;
 		instance.Description = other.Description;
+		instance.RequireAuthentication = other.RequireAuthentication;
+		instance.MaximumConcurrentConnectorRequests = other.MaximumConcurrentConnectorRequests;
 
 		// copy over config if available
 		if (other.Config != null)


### PR DESCRIPTION
When trying to use the newly added fields 'RequireAuthentication' and 'MaximumConcurrentConnectorRequests' in alpha8 I noticed, that they weren't correctly updated/created in the database.
This PR tries to fix that in adding the mapping for those 2 missing fields.