### PR TITLE
fix(connector): Add "/" to end of Authority Url when missing. Without…

### DIFF
--- a/src/Thinktecture.Relay.Connector/Options/AccessTokenManagementConfigureOptions.cs
+++ b/src/Thinktecture.Relay.Connector/Options/AccessTokenManagementConfigureOptions.cs
@@ -35,9 +35,13 @@ internal class AccessTokenManagementConfigureOptions : IConfigureOptions<AccessT
 
 	public void Configure(AccessTokenManagementOptions options)
 	{
+		var baseAddress = _relayConnectorOptions.DiscoveryDocument.AuthorizationServer;
+		if (!baseAddress.EndsWith("/"))
+		{
+			baseAddress += "/";
+		}
 		var httpClient = _httpClientFactory.CreateClient(Constants.HttpClientNames.ConnectionClose);
-
-		var baseUri = new Uri(_relayConnectorOptions.DiscoveryDocument.AuthorizationServer);
+		var baseUri = new Uri(baseAddress);
 		var fullUri = new Uri(baseUri, OidcConstants.Discovery.DiscoveryEndpoint);
 		while (!_hostApplicationLifetime.ApplicationStopping.IsCancellationRequested)
 		{


### PR DESCRIPTION
Add "/" to end of Authority Url when missing. Without "/" Uri removes end of Authority Uri.