### PR TITLE
Add the possibility to ignore the connector response

### DIFF
--- a/src/Thinktecture.Relay.Abstractions/Extensions/ClientRequestExtensions.cs
+++ b/src/Thinktecture.Relay.Abstractions/Extensions/ClientRequestExtensions.cs
@@ -49,12 +49,16 @@ public static class ClientRequestExtensions
 			HttpHeaders = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase),
 		};
 
+		if (httpStatusCode is not null)
+		{
+			response.HttpStatusCode = httpStatusCode.Value;
+		}
+
 		if (httpStatusCode == null || (int)httpStatusCode.GetValueOrDefault(HttpStatusCode.Continue) < 400)
 			return response;
 
 		response.OriginalBodySize = 0;
 		response.BodySize = 0;
-		response.HttpStatusCode = httpStatusCode.Value;
 		response.RequestFailed = true;
 
 		return response;

--- a/src/Thinktecture.Relay.Abstractions/Transport/ClientRequest.cs
+++ b/src/Thinktecture.Relay.Abstractions/Transport/ClientRequest.cs
@@ -48,4 +48,7 @@ public class ClientRequest : IClientRequest
 
 	/// <inheritdoc />
 	public bool EnableTracing { get; set; }
+
+	/// <inheritdoc />
+	public bool DiscardConnectorResponse { get; set; }
 }

--- a/src/Thinktecture.Relay.Abstractions/Transport/IClientRequest.cs
+++ b/src/Thinktecture.Relay.Abstractions/Transport/IClientRequest.cs
@@ -83,4 +83,10 @@ public interface IClientRequest
 	/// Enable tracing of this particular request.
 	/// </summary>
 	bool EnableTracing { get; set; }
+
+	/// <summary>
+	/// Enable discarding the connector response of this particular request.
+	/// </summary>
+	/// <remarks>Responses provided by an interceptor will still be returned to the client.</remarks>
+	bool DiscardConnectorResponse { get; set; }
 }

--- a/src/Thinktecture.Relay.Connector.Abstractions/Constants.cs
+++ b/src/Thinktecture.Relay.Connector.Abstractions/Constants.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using Thinktecture.Relay.Connector.Targets;
 
@@ -8,13 +9,15 @@ namespace Thinktecture.Relay.Connector;
 /// </summary>
 public static class Constants
 {
+	public static readonly string AssemblyVersion = typeof(Constants).GetAssemblyVersion();
+
 	/// <summary>
 	/// The identity scopes.
 	/// </summary>
 	public const string RelayServerScopes = "connector";
 
 	/// <summary>
-	/// The id for the catch-all <see cref="IRelayTarget{TRequest,TResponse}"/>.
+	/// The id for the catch-all <see cref="IRelayTarget"/>.
 	/// </summary>
 	public const string RelayTargetCatchAllId = "** CATCH-ALL **";
 
@@ -39,30 +42,52 @@ public static class Constants
 	public static class HeaderNames
 	{
 		/// <summary>
-		/// The url to use for acknowledging a request by issuing as POST with an empty body to it.
+		/// Contains the url to use for acknowledging a request by issuing as POST with an empty body to it.
 		/// </summary>
 		/// <remarks>This will only be present when manual acknowledgement is needed.</remarks>
 		public const string AcknowledgeUrl = "RelayServer-AcknowledgeUrl";
 
 		/// <summary>
-		/// The unique id of the request.
+		/// Contains the unique id of the request.
 		/// </summary>
+		/// <remarks>This will only be present when tracing is enabled.</remarks>
 		public const string RequestId = "RelayServer-RequestId";
 
 		/// <summary>
 		/// The unique id of the origin receiving the request.
 		/// </summary>
-		public const string OriginId = "RelayServer-OriginId";
+		/// <remarks>This will only be present when tracing is enabled.</remarks>
+		public const string RequestOriginId = "RelayServer-RequestOriginId";
 
 		/// <summary>
-		/// The machine name of the connector handling the request.
+		/// Contains the machine name of the connector handling the request.
 		/// </summary>
+		/// <remarks>This will only be present when tracing is enabled.</remarks>
 		public const string ConnectorMachineName = "RelayServer-Connector-MachineName";
 
 		/// <summary>
-		/// The version of the connector handling the request.
+		/// Contains the version of the connector handling the request.
 		/// </summary>
+		/// <remarks>This will only be present when tracing is enabled.</remarks>
 		public const string ConnectorVersion = "RelayServer-Connector-Version";
+
+		/// <summary>
+		/// Contains the unique id of the origin to use for acknowledgement.
+		/// </summary>
+		/// <remarks>This will only be present when tracing is enabled.</remarks>
+		public const string AcknowledgeOriginId = "RelayServer-AcknowledgeOriginId";
+
+		/// <summary>
+		/// Contains the start timestamp of the target handling the request.
+		/// </summary>
+		/// <remarks>This will only be present when tracing is enabled.</remarks>
+		public const string TargetStart = "RelayServer-TargetStart";
+
+		/// <summary>
+		/// Contains the duration of the target handling the request.
+		/// </summary>
+		/// <remarks>This will only be present when tracing is enabled.</remarks>
+		public const string TargetDuration = "RelayServer-TargetDuration";
 	}
 
 	/// <summary>

--- a/src/Thinktecture.Relay.Connector.Abstractions/RelayConnectorBuilderExtensions.cs
+++ b/src/Thinktecture.Relay.Connector.Abstractions/RelayConnectorBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 public static class RelayConnectorBuilderExtensions
 {
 	/// <summary>
-	/// Adds an <see cref="IRelayTarget{ClientRequest,TargetResponse}"/>.
+	/// Adds an <see cref="IRelayTarget"/>.
 	/// </summary>
 	/// <param name="builder">The <see cref="IRelayConnectorBuilder{ClientRequest,TargetResponse,AcknowledgeRequest}"/>.</param>
 	/// <param name="id">The unique id of the target.</param>
@@ -24,13 +24,12 @@ public static class RelayConnectorBuilderExtensions
 	/// <returns>The <see cref="IRelayConnectorBuilder{ClientRequest,TargetResponse,AcknowledgeRequest}"/>.</returns>
 	public static IRelayConnectorBuilder<ClientRequest, TargetResponse, AcknowledgeRequest> AddTarget<TTarget>(
 		this IRelayConnectorBuilder<ClientRequest, TargetResponse, AcknowledgeRequest> builder, string id,
-		TimeSpan? timeout = null,
-		params object[] parameters)
-		where TTarget : IRelayTarget<ClientRequest, TargetResponse>
+		TimeSpan? timeout = null, params object[] parameters)
+		where TTarget : IRelayTarget
 		=> builder.AddTarget<ClientRequest, TargetResponse, AcknowledgeRequest, TTarget>(id, timeout, parameters);
 
 	/// <summary>
-	/// Adds an <see cref="IRelayTarget{TRequest,TResponse}"/>.
+	/// Adds an <see cref="IRelayTarget"/>.
 	/// </summary>
 	/// <param name="builder">The <see cref="IRelayConnectorBuilder{TRequest,TResponse,TAcknowledge}"/>.</param>
 	/// <param name="id">The unique id of the target.</param>
@@ -41,13 +40,13 @@ public static class RelayConnectorBuilderExtensions
 	/// <typeparam name="TTarget">The type of target.</typeparam>
 	/// <typeparam name="TAcknowledge">The type of acknowledge.</typeparam>
 	/// <returns>The <see cref="IRelayConnectorBuilder{TRequest,TResponse,TAcknowledge}"/>.</returns>
-	public static IRelayConnectorBuilder<TRequest, TResponse, TAcknowledge> AddTarget<TRequest, TResponse, TAcknowledge,
-		TTarget>(
-		this IRelayConnectorBuilder<TRequest, TResponse, TAcknowledge> builder, string id, TimeSpan? timeout = null,
-		params object[] parameters)
+	public static IRelayConnectorBuilder<TRequest, TResponse, TAcknowledge>
+		AddTarget<TRequest, TResponse, TAcknowledge, TTarget>(
+			this IRelayConnectorBuilder<TRequest, TResponse, TAcknowledge> builder, string id, TimeSpan? timeout = null,
+			params object[] parameters)
 		where TRequest : IClientRequest
 		where TResponse : ITargetResponse
-		where TTarget : IRelayTarget<TRequest, TResponse>
+		where TTarget : IRelayTarget
 		where TAcknowledge : IAcknowledgeRequest
 	{
 		builder.Services.Configure<RelayTargetOptions>(options => options.Targets.Add(

--- a/src/Thinktecture.Relay.Connector.Abstractions/Targets/IRelayTarget.cs
+++ b/src/Thinktecture.Relay.Connector.Abstractions/Targets/IRelayTarget.cs
@@ -5,11 +5,43 @@ using Thinktecture.Relay.Transport;
 namespace Thinktecture.Relay.Connector.Targets;
 
 /// <summary>
-/// An implementation of a target requesting the necessary information for a connector.
+/// An implementation of a target.
+/// </summary>
+/// <remarks>This is just a marker interface.</remarks>
+public interface IRelayTarget
+{
+}
+
+/// <summary>
+/// An implementation of a target executing logic triggered by a request.
+/// </summary>
+/// <typeparam name="TRequest">The type of request.</typeparam>
+public interface IRelayTargetAction<in TRequest> : IRelayTarget
+	where TRequest : IClientRequest
+{
+	/// <summary>
+	/// Called when the target should be executed.
+	/// </summary>
+	/// <param name="request">The client request.</param>
+	/// <param name="cancellationToken">
+	/// The token to monitor for cancellation requests. The default value is
+	/// <see cref="CancellationToken.None"/>.
+	/// </param>
+	/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+	Task HandleAsync(TRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <inheritdoc />
+public interface IRelayTargetAction : IRelayTargetAction<ClientRequest>
+{
+}
+
+/// <summary>
+/// An implementation of a target providing the necessary response information for a request.
 /// </summary>
 /// <typeparam name="TRequest">The type of request.</typeparam>
 /// <typeparam name="TResponse">The type of response.</typeparam>
-public interface IRelayTarget<in TRequest, TResponse>
+public interface IRelayTargetFunc<in TRequest, TResponse> : IRelayTarget
 	where TRequest : IClientRequest
 	where TResponse : ITargetResponse
 {
@@ -23,4 +55,9 @@ public interface IRelayTarget<in TRequest, TResponse>
 	/// </param>
 	/// <returns>A <see cref="Task"/> representing the asynchronous operation, which wraps the target response.</returns>
 	Task<TResponse> HandleAsync(TRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <inheritdoc />
+public interface IRelayTargetFunc : IRelayTargetFunc<ClientRequest, TargetResponse>
+{
 }

--- a/src/Thinktecture.Relay.Connector/RelayConnector.cs
+++ b/src/Thinktecture.Relay.Connector/RelayConnector.cs
@@ -10,8 +10,6 @@ namespace Thinktecture.Relay.Connector;
 /// <remarks>This is just a convenient class for holding the transient <see cref="IConnectorConnection"/>.</remarks>
 public class RelayConnector
 {
-	internal static readonly string AssemblyVersion = typeof(RelayConnector).GetAssemblyVersion();
-
 	private readonly IConnectorConnection _connection;
 
 	/// <summary>

--- a/src/Thinktecture.Relay.Connector/Targets/RelayWebTarget.cs
+++ b/src/Thinktecture.Relay.Connector/Targets/RelayWebTarget.cs
@@ -15,8 +15,8 @@ using Thinktecture.Relay.Transport;
 
 namespace Thinktecture.Relay.Connector.Targets;
 
-/// <inheritdoc cref="IRelayTarget{TRequest,TResponse}"/>
-public partial class RelayWebTarget<TRequest, TResponse> : IRelayTarget<TRequest, TResponse>, IDisposable
+/// <inheritdoc cref="IRelayTargetFunc{TRequest,TResponse}"/>
+public partial class RelayWebTarget<TRequest, TResponse> : IRelayTargetFunc<TRequest, TResponse>, IDisposable
 // ReSharper disable RedundantNameQualifier; (this is needed in 6.0, see https://github.com/dotnet/runtime/issues/58550)
 	where TRequest : Thinktecture.Relay.Transport.IClientRequest
 	where TResponse : Thinktecture.Relay.Transport.ITargetResponse, new()

--- a/src/Thinktecture.Relay.Server.Abstractions/Constants.cs
+++ b/src/Thinktecture.Relay.Server.Abstractions/Constants.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Thinktecture.Relay.Server;
 
 /// <summary>
@@ -5,6 +7,8 @@ namespace Thinktecture.Relay.Server;
 /// </summary>
 public static class Constants
 {
+	public static readonly string AssemblyVersion = typeof(Constants).GetAssemblyVersion();
+
 	/// <summary>
 	/// The authentication scheme to use.
 	/// </summary>
@@ -26,14 +30,53 @@ public static class Constants
 	public const string DefaultAuthenticationScope = "connector";
 
 	/// <summary>
+	/// The default relay path to use.
+	/// </summary>
+	public const string DefaultRelayPath = "relay";
+
+	/// <summary>
+	/// The default queue path to use.
+	/// </summary>
+	public const string DefaultQueuePath = "queue";
+
+	/// <summary>
+	/// The default trace path to use.
+	/// </summary>
+	public const string DefaultTracePath = "trace";
+
+	/// <summary>
 	/// Constants for HTTP headers.
 	/// </summary>
 	public static class HeaderNames
 	{
 		/// <summary>
-		/// Enables tracing of the particular request when present.
+		/// Contains the unique id of the request.
 		/// </summary>
-		/// <remarks>The value of the header is ignored.</remarks>
-		public const string EnableTracing = "RelayServer-EnableTracing";
+		/// <remarks>This will only be present when tracing is enabled.</remarks>
+		public const string RequestId = "RelayServer-RequestId";
+
+		/// <summary>
+		/// Contains the machine name of the server handling the request.
+		/// </summary>
+		/// <remarks>This will only be present when tracing is enabled.</remarks>
+		public const string ServerMachineName = "RelayServer-Server-MachineName";
+
+		/// <summary>
+		/// Contains the version of the server handling the request.
+		/// </summary>
+		/// <remarks>This will only be present when tracing is enabled.</remarks>
+		public const string ServerVersion = "RelayServer-Server-Version";
+
+		/// <summary>
+		/// Contains the start timestamp of the target handling the request.
+		/// </summary>
+		/// <remarks>This will only be present when tracing is enabled.</remarks>
+		public const string TargetStart = "RelayServer-TargetStart";
+
+		/// <summary>
+		/// Contains the duration of the target handling the request.
+		/// </summary>
+		/// <remarks>This will only be present when tracing is enabled.</remarks>
+		public const string TargetDuration = "RelayServer-TargetDuration";
 	}
 }

--- a/src/Thinktecture.Relay.Server.Abstractions/Transport/IRelayTargetResponseWriter.cs
+++ b/src/Thinktecture.Relay.Server.Abstractions/Transport/IRelayTargetResponseWriter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -8,13 +9,16 @@ namespace Thinktecture.Relay.Server.Transport;
 /// <summary>
 /// An implementation of a writer for <see cref="ITargetResponse"/> to <see cref="HttpResponse"/>.
 /// </summary>
-/// <typeparam name="T">The type of response.</typeparam>
-public interface IRelayTargetResponseWriter<in T>
-	where T : class, ITargetResponse
+/// <typeparam name="TRequest">The type of request.</typeparam>
+/// <typeparam name="TResponse">The type of response.</typeparam>
+public interface IRelayTargetResponseWriter<in TRequest, in TResponse>
+	where TRequest : IClientRequest
+	where TResponse : class, ITargetResponse
 {
 	/// <summary>
 	/// Writes the target response to the <see cref="HttpResponse"/>.
 	/// </summary>
+	/// <param name="clientRequest">An <see cref="IClientRequest"/>.</param>
 	/// <param name="targetResponse">An <see cref="ITargetResponse"/>.</param>
 	/// <param name="httpResponse">The <see cref="HttpResponse"/>.</param>
 	/// <param name="cancellationToken">
@@ -22,5 +26,6 @@ public interface IRelayTargetResponseWriter<in T>
 	/// <see cref="CancellationToken.None"/>.
 	/// </param>
 	/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-	Task WriteAsync(T? targetResponse, HttpResponse httpResponse, CancellationToken cancellationToken = default);
+	Task WriteAsync(TRequest clientRequest, TResponse? targetResponse, HttpResponse httpResponse,
+		CancellationToken cancellationToken = default);
 }

--- a/src/Thinktecture.Relay.Server/ApplicationBuilderExtensions.cs
+++ b/src/Thinktecture.Relay.Server/ApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Thinktecture.Relay.Acknowledgement;
+using Thinktecture.Relay.Server;
 using Thinktecture.Relay.Server.DependencyInjection;
 using Thinktecture.Relay.Server.Middleware;
 using Thinktecture.Relay.Transport;
@@ -33,7 +34,12 @@ public static class ApplicationBuilderExtensions
 		where TResponse : class, ITargetResponse, new()
 		where TAcknowledge : IAcknowledgeRequest
 	{
-		builder.Map("/relay", app => app.UseMiddleware<RelayMiddleware<TRequest, TResponse, TAcknowledge>>());
+		builder.Map($"/{Constants.DefaultRelayPath}", true,
+			app => app.UseMiddleware<RelayMiddleware<TRequest, TResponse, TAcknowledge>>());
+		builder.Map($"/{Constants.DefaultQueuePath}", true,
+			app => app.UseMiddleware<RelayMiddleware<TRequest, TResponse, TAcknowledge>>());
+		builder.Map($"/{Constants.DefaultTracePath}", true,
+			app => app.UseMiddleware<RelayMiddleware<TRequest, TResponse, TAcknowledge>>());
 
 		foreach (var part in builder.ApplicationServices.GetServices<IApplicationBuilderPart>())
 		{

--- a/src/Thinktecture.Relay.Server/ServiceCollectionExtensions.cs
+++ b/src/Thinktecture.Relay.Server/ServiceCollectionExtensions.cs
@@ -74,7 +74,9 @@ public static class ServiceCollectionExtensions
 		services.TryAddScoped<IRelayRequestLogger<TRequest, TResponse>, RelayRequestLogger<TRequest, TResponse>>();
 		services.TryAddScoped<DiscoveryDocumentBuilder>();
 
-		services.TryAddSingleton<IRelayTargetResponseWriter<TResponse>, RelayTargetResponseWriter<TResponse>>();
+		services
+			.TryAddSingleton<IRelayTargetResponseWriter<TRequest, TResponse>,
+				RelayTargetResponseWriter<TRequest, TResponse>>();
 		services.TryAddSingleton<IRelayClientRequestFactory<TRequest>, RelayClientRequestFactory<TRequest>>();
 		services.TryAddSingleton<IRequestCoordinator<TRequest>, RequestCoordinator<TRequest>>();
 		services.TryAddSingleton<IResponseCoordinator<TResponse>, ResponseCoordinator<TResponse>>();

--- a/src/docker/Thinktecture.Relay.Connector.Docker/Startup.cs
+++ b/src/docker/Thinktecture.Relay.Connector.Docker/Startup.cs
@@ -25,17 +25,18 @@ public static class Startup
 		services
 			.AddRelayConnector(options => configuration.GetSection("RelayConnector").Bind(options))
 			.AddSignalRConnectorTransport()
-			.AddTarget<InProcTarget>("inproc");
+			.AddTarget<InProcFunc>("inprocfunc")
+			.AddTarget<InProcAction>("inprocaction");
 
 		services.AddHostedService<ConnectorService>();
 	}
 }
 
-internal class InProcTarget : IRelayTarget<ClientRequest, TargetResponse>
+internal class InProcFunc : IRelayTargetFunc
 {
 	private ILogger _logger;
 
-	public InProcTarget(ILogger<InProcTarget> logger)
+	public InProcFunc(ILogger<InProcFunc> logger)
 		=> _logger = logger;
 
 	public async Task<TargetResponse> HandleAsync(ClientRequest request, CancellationToken cancellationToken = default)
@@ -79,6 +80,12 @@ internal class InProcTarget : IRelayTarget<ClientRequest, TargetResponse>
 
 		return response;
 	}
+}
+
+internal class InProcAction : IRelayTargetAction
+{
+	public Task HandleAsync(ClientRequest request, CancellationToken cancellationToken = default)
+		=> Task.Delay(TimeSpan.FromSeconds(42), cancellationToken);
 }
 
 internal class ConnectorService : IHostedService


### PR DESCRIPTION
With these changes, the middleware will be used for more than one path, triggering different behaviors:

- `/relay`: This is the known path for relaying a request to a tenant and waiting for its response.
- `/queue`: This is new and switches on this request's "ignore connector response" feature. The client immediately receives a response with HTTP Status Code 202 (Accepted).
- `/trace`: This is new and supersedes the "enable tracing" header. As this is a tracing from server to connector and back, the response cannot be ignored, but instead a HTTP Status Code 204 (No Content) will be returned in case of an IRelayTargetAction.

This also introduces a breaking change, as the IRelayTarget interface is now a marker interface. Two new interfaces are introduced:

- `IRelayTargetAction`: With this interface, it is possible to implement a target that does not return anything. The connector automatically returns HTTP Status Code 204 (No Content) at the end as the response.
- `IRelayTargetFunc`: This is the previous `IRelayTarget` interface with a new name. The migration scenario is to switch to this interface.

Fixes #462 

Warning: #465 needs to be merged first.