### PR TITLE
Remove deprecated X- from custom headers

### DIFF
--- a/docs/development-getting-started.md
+++ b/docs/development-getting-started.md
@@ -12,7 +12,7 @@ Scripts to help building and running the system are provided as
 and Linux.
 
 A compose file is provided to build all the docker images (`src/docker/docker-compose.yml`). You can build the images
-with the `docker compose build` command.
+with the `docker compose build` command. An environment variable `RABBITMQ_ERLANG_COOKIE` needs to be set.
 
 ## First time Development & Test-Setup
 

--- a/src/Thinktecture.Relay.Connector.Abstractions/Constants.cs
+++ b/src/Thinktecture.Relay.Connector.Abstractions/Constants.cs
@@ -42,27 +42,27 @@ public static class Constants
 		/// The url to use for acknowledging a request by issuing as POST with an empty body to it.
 		/// </summary>
 		/// <remarks>This will only be present when manual acknowledgement is needed.</remarks>
-		public const string AcknowledgeUrl = "X-RelayServer-AcknowledgeUrl";
+		public const string AcknowledgeUrl = "RelayServer-AcknowledgeUrl";
 
 		/// <summary>
 		/// The unique id of the request.
 		/// </summary>
-		public const string RequestId = "X-RelayServer-RequestId";
+		public const string RequestId = "RelayServer-RequestId";
 
 		/// <summary>
 		/// The unique id of the origin receiving the request.
 		/// </summary>
-		public const string OriginId = "X-RelayServer-OriginId";
+		public const string OriginId = "RelayServer-OriginId";
 
 		/// <summary>
 		/// The machine name of the connector handling the request.
 		/// </summary>
-		public const string ConnectorMachineName = "X-RelayServer-Connector-MachineName";
+		public const string ConnectorMachineName = "RelayServer-Connector-MachineName";
 
 		/// <summary>
 		/// The version of the connector handling the request.
 		/// </summary>
-		public const string ConnectorVersion = "X-RelayServer-Connector-Version";
+		public const string ConnectorVersion = "RelayServer-Connector-Version";
 	}
 
 	/// <summary>

--- a/src/Thinktecture.Relay.Server.Abstractions/Constants.cs
+++ b/src/Thinktecture.Relay.Server.Abstractions/Constants.cs
@@ -33,7 +33,7 @@ public static class Constants
 		/// <summary>
 		/// Enables tracing of the particular request when present.
 		/// </summary>
-		/// <remarks>The value is ignored.</remarks>
-		public const string EnableTracing = "X-RelayServer-EnableTracing";
+		/// <remarks>The value of the header is ignored.</remarks>
+		public const string EnableTracing = "RelayServer-EnableTracing";
 	}
 }

--- a/src/Thinktecture.Relay.sln
+++ b/src/Thinktecture.Relay.sln
@@ -92,25 +92,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Thinktecture.Relay.Server.I
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Thinktecture.Relay.Server.Management", "Thinktecture.Relay.Server.Management\Thinktecture.Relay.Server.Management.csproj", "{4EF4176E-34E3-477A-8CB1-982A318C3C30}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "environments", "environments", "{0A0F0537-6270-4D1C-AFF7-F998AECCF938}"
-	ProjectSection(SolutionItems) = preProject
-		docker\environments\relay_connector.env = docker\environments\relay_connector.env
-		docker\environments\relay_connector_a1.env = docker\environments\relay_connector_a1.env
-		docker\environments\relay_connector_a2.env = docker\environments\relay_connector_a2.env
-		docker\environments\relay_connector_b1.env = docker\environments\relay_connector_b1.env
-		docker\environments\relay_connector_b2.env = docker\environments\relay_connector_b2.env
-		docker\environments\relay_identityserver.env = docker\environments\relay_identityserver.env
-		docker\environments\relay_logging_seq.env = docker\environments\relay_logging_seq.env
-		docker\environments\relay_management.env = docker\environments\relay_management.env
-		docker\environments\relay_persistence_postgresql.env = docker\environments\relay_persistence_postgresql.env
-		docker\environments\relay_server.env = docker\environments\relay_server.env
-		docker\environments\relay_server_a.env = docker\environments\relay_server_a.env
-		docker\environments\relay_server_b.env = docker\environments\relay_server_b.env
-		docker\environments\relay_transport_rabbitmq.env = docker\environments\relay_transport_rabbitmq.env
-		docker\environments\relay_transport_rabbitmq2.env = docker\environments\relay_transport_rabbitmq2.env
-		docker\environments\relay_transport_rabbitmq1.env = docker\environments\relay_transport_rabbitmq1.env
-	EndProjectSection
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -231,7 +212,6 @@ Global
 		{84437CA2-F563-4D08-A1CF-A07ECB154884} = {EACF91C8-8B43-4E87-8859-4902B3CC7F63}
 		{CD190E32-1B0F-48D4-BFF1-43BD388A7C4A} = {D8D76BB9-1D64-43C5-9B7E-710CF4A35374}
 		{4EF4176E-34E3-477A-8CB1-982A318C3C30} = {D8D76BB9-1D64-43C5-9B7E-710CF4A35374}
-		{0A0F0537-6270-4D1C-AFF7-F998AECCF938} = {3126FA1D-9755-4842-BDE0-34F7EADF9969}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9CE554FF-A10B-4F63-B480-ED9455F16873}

--- a/src/docker/Thinktecture.Relay.Connector.Docker/Dockerfile
+++ b/src/docker/Thinktecture.Relay.Connector.Docker/Dockerfile
@@ -42,4 +42,6 @@ RUN chmod u-s /usr/bin/gpasswd /usr/bin/chsh /bin/umount /bin/mount /sbin/unix_c
 USER relay
 COPY --chown=relay --from=build /app .
 
+ENV DOTNET_ENVIRONMENT=Development
+
 ENTRYPOINT ["dotnet", "Thinktecture.Relay.Connector.Docker.dll"]

--- a/src/docker/Thinktecture.Relay.Connector.Docker/appsettings.Development.json
+++ b/src/docker/Thinktecture.Relay.Connector.Docker/appsettings.Development.json
@@ -18,59 +18,61 @@
   },
   "RelayConnector": {
     "RelayServerBaseUri": "http://localhost:5000",
+    "TenantName": "TestTenant1",
+    "TenantSecret": "<Strong!Passw0rd>",
     "Targets": {
       "mocky1": {
         "Type": "RelayWebTarget",
         "Timeout": "00:00:30",
-        // returns simple JSON ({ "Hello": "World" }) (followed by "?mocky-delay=#ms" to simulate a long running request delayed by #)
+        "Comment": "returns simple JSON ({ \"Hello\": \"World\" }) (followed by '?mocky-delay=#ms' to simulate a long running request delayed by #)",
         "Url": "https://run.mocky.io/v3/9c5f5b7f-a2ce-4067-8d0d-5130feb40e56"
       },
       "mocky2": {
         "Type": "RelayWebTarget",
         "Timeout": "00:00:02",
-        // returns HTTP status NO CONTENT (followed by "?mocky-delay=#ms" to simulate a long running request delayed by #)
+        "Comment": "returns HTTP status NO CONTENT (followed by '?mocky-delay=#ms' to simulate a long running request delayed by #)",
         "Url": "https://run.mocky.io/v3/dd0c23d8-6802-46ea-a188-675d022d0e4d"
       },
       "mocky3": {
         "Type": "RelayWebTarget",
         "Timeout": "00:00:02",
-        // returns big JOSN (followed by "?mocky-delay=#ms" to simulate a long running request delayed by #)
+        "Comment": "returns big JOSN (followed by '?mocky-delay=#ms' to simulate a long running request delayed by #)",
         "Url": "https://run.mocky.io/v3/b0949784-114b-4ea9-80a8-f08aca93c796"
       },
       "mocky4": {
         "Type": "RelayWebTarget",
-        // returns 307
+        "Comment": "returns 307",
         "Url": "https://run.mocky.io/v3/09b75630-c3ff-4467-876d-ff389a110e30"
       },
       "status": {
         "Type": "RelayWebTarget",
         "Timeout": "00:00:02",
-        // returns HTTP status by appended code (followed by "?sleep=#" to simulate a long running request delayed by # msec)
+        "Comment": "returns HTTP status by appended code (followed by '?sleep=#' to simulate a long running request delayed by # msec)",
         "Url": "https://httpstat.us/"
       },
       "swapi": {
         "Type": "RelayWebTarget",
-        // returns more complex JSON (e.g. "/api/people/1/")
+        "Comment": "returns more complex JSON (e.g. '/api/people/1/')",
         "Url": "https://swapi.dev/",
         "Options": "FollowRedirect"
       },
       "picsum": {
         "Type": "RelayWebTarget",
-        // returns a random 4k image
+        "Comment": "returns a random 4k image",
         "Url": "https://picsum.photos/3840/2160",
         "Options": "FollowRedirect"
       },
       "smallpdf": {
         "Type": "RelayWebTarget",
         "Timeout": "01:00:00",
-        // returns a small pdf (around 10 Mb)
+        "Comment": "returns a small pdf (around 10 Mb)",
         "Url": "https://link.testfile.org/PDF10MB",
         "Options": "FollowRedirect"
       },
       "bigpdf": {
         "Type": "RelayWebTarget",
         "Timeout": "01:00:00",
-        // returns a really big pdf (around 100 Mb)
+        "Comment": "returns a really big pdf (around 100 Mb)",
         "Url": "https://link.testfile.org/PDF100MB",
         "Options": "FollowRedirect"
       },

--- a/src/docker/Thinktecture.Relay.Connector.Docker/appsettings.json
+++ b/src/docker/Thinktecture.Relay.Connector.Docker/appsettings.json
@@ -1,17 +1,2 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "System": "Warning"
-      }
-    }
-  },
-  "RelayConnector": {
-    "RelayServerBaseUri": "http://relay_server:5000",
-    "TenantName": "TestTenant1",
-    "TenantSecret": "<Strong!Passw0rd>"
-  },
-  "AllowedHosts": "*"
 }

--- a/src/docker/Thinktecture.Relay.IdentityServer.Docker/Dockerfile
+++ b/src/docker/Thinktecture.Relay.IdentityServer.Docker/Dockerfile
@@ -51,6 +51,8 @@ COPY --chown=idsrv --from=build /app .
 EXPOSE 5000
 
 ENV ASPNETCORE_URLS=http://+:5000
+ENV Serilog__Properties__System=IdentityServer
 ENV CertificateStore__Path=/var/signingkeys
+ENV CertificateStore__Password=<Strong!Passw0rd>
 
 ENTRYPOINT ["dotnet", "Thinktecture.Relay.IdentityServer.Docker.dll"]

--- a/src/docker/Thinktecture.Relay.IdentityServer.Docker/appsettings.Development.json
+++ b/src/docker/Thinktecture.Relay.IdentityServer.Docker/appsettings.Development.json
@@ -20,6 +20,6 @@
     "PostgreSql": "host=localhost;database=relayserver;username=relayserver;password=<Strong!Passw0rd>"
   },
   "CertificateStore": {
-    "Path": "./certificates"
+    "Password": "<Strong!Passw0rd>"
   }
 }

--- a/src/docker/Thinktecture.Relay.IdentityServer.Docker/appsettings.json
+++ b/src/docker/Thinktecture.Relay.IdentityServer.Docker/appsettings.json
@@ -1,18 +1,2 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "System": "Warning"
-      }
-    }
-  },
-  "ConnectionStrings": {
-    "PostgreSql": "host=relay_persistence_postgresql;database=relayserver;username=relayserver;password=<Strong!Passw0rd>"
-  },
-  "CertificateStore": {
-    "Password": "<Strong!Password>"
-  },
-  "AllowedHosts": "*"
 }

--- a/src/docker/Thinktecture.Relay.ManagementApi.Docker/Dockerfile
+++ b/src/docker/Thinktecture.Relay.ManagementApi.Docker/Dockerfile
@@ -47,5 +47,9 @@ COPY --chown=relay --from=build /app .
 EXPOSE 5000
 
 ENV ASPNETCORE_URLS=http://+:5000
+ENV Serilog__Properties__System=Management
+ENV Authentication__ApiKey__ApiKeys__read-key__managementapi=read
+ENV Authentication__ApiKey__ApiKeys__write-key__managementapi=write
+ENV Authentication__ApiKey__ApiKeys__readwrite-key__managementapi=readwrite
 
 ENTRYPOINT ["dotnet", "Thinktecture.Relay.ManagementApi.Docker.dll"]

--- a/src/docker/Thinktecture.Relay.ManagementApi.Docker/appsettings.Development.json
+++ b/src/docker/Thinktecture.Relay.ManagementApi.Docker/appsettings.Development.json
@@ -18,5 +18,14 @@
   },
   "ConnectionStrings": {
     "PostgreSql": "host=localhost;database=relayserver;username=relayserver;password=<Strong!Passw0rd>"
+  },
+  "Authentication": {
+    "ApiKey": {
+      "ApiKeys": {
+        "read-key": { "managementapi": "read" },
+        "write-key": { "managementapi": "write" },
+        "readwrite-key": { "managementapi": "readwrite" }
+      }
+    }
   }
 }

--- a/src/docker/Thinktecture.Relay.ManagementApi.Docker/appsettings.json
+++ b/src/docker/Thinktecture.Relay.ManagementApi.Docker/appsettings.json
@@ -1,26 +1,2 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "System": "Warning"
-      }
-    }
-  },
-  "ConnectionStrings": {
-    "PostgreSql": "host=relay_persistence_postgresql;database=relayserver;username=relayserver;password=<Strong!Passw0rd>"
-  },
-  "Authentication": {
-    "ApiKey": {
-      "HeaderName": "TT-Api-Key",
-      "ApiKeys": {
-        // map api keys to corresponding claims
-        "read-key": { "managementapi": "read" },
-        "write-key": { "managementapi": "write" },
-        "readwrite-key": { "managementapi": "readwrite" }
-      }
-    }
-  },
-  "AllowedHosts": "*"
 }

--- a/src/docker/Thinktecture.Relay.Server.Docker/Dockerfile
+++ b/src/docker/Thinktecture.Relay.Server.Docker/Dockerfile
@@ -56,5 +56,8 @@ COPY --chown=relay --from=build /app .
 EXPOSE 5000
 
 ENV ASPNETCORE_URLS=http://+:5000
+ENV RabbitMq__ClusterHosts=relay_transport_rabbitmq1,relay_transport_rabbitmq2
+ENV BodyStore__StoragePath=/var/bodystore
+ENV Authentication__Authority=http://relay_identityserver:5000
 
 ENTRYPOINT ["dotnet", "Thinktecture.Relay.Server.Docker.dll"]

--- a/src/docker/Thinktecture.Relay.Server.Docker/appsettings.Development.json
+++ b/src/docker/Thinktecture.Relay.Server.Docker/appsettings.Development.json
@@ -19,11 +19,16 @@
   "ConnectionStrings": {
     "PostgreSql": "host=localhost;database=relayserver;username=relayserver;password=<Strong!Passw0rd>"
   },
+  "Kestrel": {
+    "Limits": {
+      "MaxRequestBodySize": 115343360
+    }
+  },
   "Authentication": {
     "Authority": "http://localhost:5002"
   },
   "RabbitMq": {
-    "Uri": "amqp://relayserver:<Strong!Passw0rd>@localhost",
+    "Uri": "amqp://guest:guest@localhost",
     "ClusterHosts": "localhost:5672,localhost:5673"
   },
   "RelayServer": {

--- a/src/docker/Thinktecture.Relay.Server.Docker/appsettings.json
+++ b/src/docker/Thinktecture.Relay.Server.Docker/appsettings.json
@@ -1,26 +1,2 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "System": "Warning"
-      }
-    }
-  },
-  "ConnectionStrings": {
-    "PostgreSql": "host=relay_persistence_postgresql;database=relayserver;username=relayserver;password=<Strong!Passw0rd>"
-  },
-  "Authentication": {
-    "Authority": "http://relay_identityserver:5000"
-  },
-  "RabbitMq": {
-    "Uri": "amqp://relayserver:<Strong!Passw0rd>@relay_transport_rabbitmq1"
-  },
-  "AllowedHosts": "*",
-  "Kestrel": {
-    "Limits": {
-      "MaxRequestBodySize": 115343360
-    }
-  }
 }

--- a/src/docker/Thinktecture.Relay.StatisticsApi.Docker/appsettings.json
+++ b/src/docker/Thinktecture.Relay.StatisticsApi.Docker/appsettings.json
@@ -1,15 +1,2 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "System": "Warning"
-      }
-    }
-  },
-  "ConnectionStrings": {
-    "PostgreSql": "host=relay_persistence_postgresql;database=relayserver;username=relayserver;password=<Strong!Passw0rd>"
-  },
-  "AllowedHosts": "*"
 }

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -5,7 +5,28 @@ x-defaults: &defaults
 x-rabbit-defaults: &rabbit-defaults
   <<: *defaults
   image: rabbitmq:management-alpine
-  command: ["bash", "-c", "echo -n 'V2VsY29tZSB0byBUaGlua3RlY3R1cmUgUmVsYXlTZXJ2ZXIgMyDigJMgWW91IHN1Y2Nlc3NmdWxseSBkZWNvZGVkIG91ciBmYWtlIEVSTEFORyBjb29raWUgY29udGFpbmluZyB0aGlzIG1lc3NhZ2Uu' > /var/lib/rabbitmq/.erlang.cookie; chmod 400 /var/lib/rabbitmq/.erlang.cookie; rabbitmq-server"]
+  secrets:
+    - source: erlang-cookie
+      target: /var/lib/rabbitmq/.erlang.cookie
+      mode: 0600
+x-rabbit-env: &rabbit-env
+  RABBITMQ_DEFAULT_USER: guest
+  RABBITMQ_DEFAULT_PASS: guest
+  RABBITMQ_SERVER_START_ARGS: -rabbit cluster_nodes {['rabbit@relay_transport_rabbitmq1','rabbit@relay_transport_rabbitmq2'],disc} cluster_name rabbit@relay_transport
+
+x-db-connection: &db-connection
+  ConnectionStrings__PostgreSql: host=relay_persistence_postgresql;database=relayserver;username=relayserver;password=<Strong!Passw0rd>
+
+x-logging: &logging
+  Serilog__MinimumLevel__Default: Verbose
+  Serilog__MinimumLevel__Override__Microsoft: Warning
+  Serilog__MinimumLevel__Override__System: Warning
+  Serilog__WriteTo__0__Name: Seq
+  Serilog__WriteTo__0__Args__ServerUrl: http://relay_logging_seq
+
+secrets:
+  erlang-cookie:
+    environment: RABBITMQ_ERLANG_COOKIE
 
 services:
   relay_transport_rabbitmq1:
@@ -14,38 +35,42 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
-    env_file:
-      - environments/relay_transport_rabbitmq.env
-      - environments/relay_transport_rabbitmq1.env
+    environment:
+      <<: *rabbit-env
+      RABBITMQ_NODENAME: rabbit@relay_transport_rabbitmq1
   relay_transport_rabbitmq2:
     <<: *rabbit-defaults
     container_name: relay_transport_rabbitmq2
     ports:
       - "5673:5672"
       - "15673:15672"
-    env_file:
-      - environments/relay_transport_rabbitmq.env
-      - environments/relay_transport_rabbitmq2.env
+    environment:
+      <<: *rabbit-env
+      RABBITMQ_NODENAME: rabbit@relay_transport_rabbitmq2
+
   relay_logging_seq:
     <<: *defaults
     image: datalust/seq
     container_name: relay_logging_seq
     ports:
       - "5341:80"
-    env_file:
-      - environments/relay_logging_seq.env
+    environment:
+      ACCEPT_EULA: Y
     volumes:
       - seq-data:/data
+
   relay_persistence_postgresql:
     <<: *defaults
     image: postgres:15-alpine
     container_name: relay_persistence_postgresql
     ports:
       - "5432:5432"
-    env_file:
-      - environments/relay_persistence_postgresql.env
+    environment:
+      POSTGRES_USER: relayserver
+      POSTGRES_PASSWORD: <Strong!Passw0rd>
     volumes:
       - postgresql-data:/var/lib/postgresql/data
+
   relay_server_migrations:
     <<: *defaults
     image: relay_server
@@ -53,9 +78,13 @@ services:
       context: ..
       dockerfile: ./docker/Thinktecture.Relay.Server.Docker/Dockerfile
     container_name: relay_server_migrations
+    environment:
+      <<: [*db-connection, *logging]
+      Serilog__Properties__System: Migration
     depends_on:
       - relay_persistence_postgresql
     entrypoint: ["dotnet", "Thinktecture.Relay.Server.Docker.dll", "migrate-only=true"]
+
   relay_management:
     <<: *defaults
     image: relay_management
@@ -65,10 +94,11 @@ services:
     container_name: relay_management
     ports:
       - "5004:5000"
-    env_file:
-      - environments/relay_management.env
+    environment:
+      <<: [*db-connection, *logging]
     depends_on:
       - relay_server_migrations
+
   relay_tenant_seed:
     <<: *defaults
     image: curlimages/curl
@@ -76,7 +106,8 @@ services:
     depends_on:
       - relay_server_migrations
       - relay_management
-    command: [ "sh", "-c", "sleep 5 && curl -H \"Accept: application/json\" -H \"Content-Type: application/json\" -H \"TT-Api-Key: write-key\" --data-raw '{ \"name\": \"TestTenant1\", \"credentials\": [{ \"plainTextValue\": \"<Strong!Passw0rd>\" }]}' http://relay_management:5000/management/tenants && curl -H \"Accept: application/json\" -H \"Content-Type: application/json\" -H \"TT-Api-Key: write-key\" --data-raw '{ \"name\": \"TestTenant2\", \"credentials\": [{ \"plainTextValue\": \"<Strong!Passw0rd>\" }]}' http://relay_management:5000/management/tenants" ]
+    command: [ "sh", "-c", "sleep 5 && curl -H \"Accept: application/json\" -H \"Content-Type: application/json\" -H \"Api-Key: write-key\" --data-raw '{ \"name\": \"TestTenant1\", \"credentials\": [{ \"plainTextValue\": \"<Strong!Passw0rd>\" }]}' http://relay_management:5000/management/tenants && curl -H \"Accept: application/json\" -H \"Content-Type: application/json\" -H \"Api-Key: write-key\" --data-raw '{ \"name\": \"TestTenant2\", \"credentials\": [{ \"plainTextValue\": \"<Strong!Passw0rd>\" }]}' http://relay_management:5000/management/tenants" ]
+
   relay_identityserver:
     <<: *defaults
     image: relay_identityserver
@@ -86,19 +117,21 @@ services:
     container_name: relay_identityserver
     ports:
       - "5002:5000"
-    env_file:
-      - environments/relay_identityserver.env
+    environment:
+      <<: [*db-connection, *logging]
     depends_on:
       - relay_server_migrations
+
   relay_server_a:
     <<: *defaults
     image: relay_server
     container_name: relay_server_a
     ports:
       - "5010:5000"
-    env_file:
-      - environments/relay_server.env
-      - environments/relay_server_a.env
+    environment:
+      <<: [*db-connection, *logging]
+      Serilog__Properties__System: RelayServerA
+      RabbitMq__Uri: amqp://guest:guest@relay_transport_rabbitmq1
     volumes:
       - relay-bodystore:/var/bodystore
     depends_on:
@@ -110,14 +143,16 @@ services:
     container_name: relay_server_b
     ports:
       - "5011:5000"
-    env_file:
-      - environments/relay_server.env
-      - environments/relay_server_b.env
+    environment:
+      <<: [*db-connection, *logging]
+      Serilog__Properties__System: RelayServerB
+      RabbitMq__Uri: amqp://guest:guest@relay_transport_rabbitmq2
     volumes:
       - relay-bodystore:/var/bodystore
     depends_on:
       - relay_server_migrations
       - relay_identityserver
+
   relay_connector_a1:
     <<: *defaults
     image: relay_connector
@@ -125,36 +160,45 @@ services:
       context: ..
       dockerfile: ./docker/Thinktecture.Relay.Connector.Docker/Dockerfile
     container_name: relay_connector_a1
-    env_file:
-      - environments/relay_connector.env
-      - environments/relay_connector_a1.env
+    environment:
+      <<: *logging
+      Serilog__Properties__System: Connector_A1
+      RelayConnector__RelayServerBaseUri: http://relay_server_a:5000
+      RelayConnector__TenantName: TestTenant1
     depends_on:
       - relay_server_a
   relay_connector_a2:
     <<: *defaults
     image: relay_connector
     container_name: relay_connector_a2
-    env_file:
-      - environments/relay_connector.env
-      - environments/relay_connector_a2.env
+    environment:
+      <<: *logging
+      Serilog__Properties__System: Connector_A2
+      RelayConnector__RelayServerBaseUri: http://relay_server_a:5000
+      RelayConnector__TenantName: TestTenant1
     depends_on:
       - relay_connector_a1
+
   relay_connector_b1:
     <<: *defaults
     image: relay_connector
     container_name: relay_connector_b1
-    env_file:
-      - environments/relay_connector.env
-      - environments/relay_connector_b1.env
+    environment:
+      <<: *logging
+      Serilog__Properties__System: Connector_B1
+      RelayConnector__RelayServerBaseUri: http://relay_server_b:5000
+      RelayConnector__TenantName: TestTenant2
     depends_on:
       - relay_server_b
   relay_connector_b2:
     <<: *defaults
     image: relay_connector
     container_name: relay_connector_b2
-    env_file:
-      - environments/relay_connector.env
-      - environments/relay_connector_b2.env
+    environment:
+      <<: *logging
+      Serilog__Properties__System: Connector_B2
+      RelayConnector__RelayServerBaseUri: http://relay_server_b:5000
+      RelayConnector__TenantName: TestTenant2
     depends_on:
       - relay_connector_b1
 

--- a/src/docker/environments/relay_connector.env
+++ b/src/docker/environments/relay_connector.env
@@ -1,6 +1,0 @@
-DOTNET_ENVIRONMENT=Development
-Serilog__MinimumLevel__Default=Information
-Serilog__MinimumLevel__Override__Microsoft=Warning
-Serilog__MinimumLevel__Override__System=Warning
-Serilog__WriteTo__0__Name=Seq
-Serilog__WriteTo__0__Args__ServerUrl=http://relay_logging_seq

--- a/src/docker/environments/relay_connector_a1.env
+++ b/src/docker/environments/relay_connector_a1.env
@@ -1,2 +1,0 @@
-Serilog__Properties__System=Connector_A1
-RelayConnector__RelayServerBaseUri=http://relay_server_a:5000

--- a/src/docker/environments/relay_connector_a2.env
+++ b/src/docker/environments/relay_connector_a2.env
@@ -1,2 +1,0 @@
-Serilog__Properties__System=Connector_A2
-RelayConnector__RelayServerBaseUri=http://relay_server_a:5000

--- a/src/docker/environments/relay_connector_b1.env
+++ b/src/docker/environments/relay_connector_b1.env
@@ -1,3 +1,0 @@
-Serilog__Properties__System=Connector_B1
-RelayConnector__RelayServerBaseUri=http://relay_server_b:5000
-RelayConnector__TenantName=TestTenant2

--- a/src/docker/environments/relay_connector_b2.env
+++ b/src/docker/environments/relay_connector_b2.env
@@ -1,3 +1,0 @@
-Serilog__Properties__System=Connector_B2
-RelayConnector__RelayServerBaseUri=http://relay_server_b:5000
-RelayConnector__TenantName=TestTenant2

--- a/src/docker/environments/relay_identityserver.env
+++ b/src/docker/environments/relay_identityserver.env
@@ -1,6 +1,0 @@
-Serilog__MinimumLevel__Default=Verbose
-Serilog__MinimumLevel__Override__Microsoft=Information
-Serilog__MinimumLevel__Override__Microsoft.Hosting.Lifetime=Information
-Serilog__WriteTo__0__Name=Seq
-Serilog__WriteTo__0__Args__ServerUrl=http://relay_logging_seq
-Serilog__Properties__System=IdentityServer

--- a/src/docker/environments/relay_logging_seq.env
+++ b/src/docker/environments/relay_logging_seq.env
@@ -1,1 +1,0 @@
-ACCEPT_EULA=Y

--- a/src/docker/environments/relay_management.env
+++ b/src/docker/environments/relay_management.env
@@ -1,6 +1,0 @@
-Serilog__MinimumLevel__Default=Verbose
-Serilog__MinimumLevel__Override__Microsoft=Information
-Serilog__MinimumLevel__Override__Microsoft.Hosting.Lifetime=Information
-Serilog__WriteTo__0__Name=Seq
-Serilog__WriteTo__0__Args__ServerUrl=http://relay_logging_seq
-Serilog__Properties__System=Management

--- a/src/docker/environments/relay_persistence_postgresql.env
+++ b/src/docker/environments/relay_persistence_postgresql.env
@@ -1,2 +1,0 @@
-POSTGRES_USER=relayserver
-POSTGRES_PASSWORD=<Strong!Passw0rd>

--- a/src/docker/environments/relay_server.env
+++ b/src/docker/environments/relay_server.env
@@ -1,4 +1,0 @@
-Serilog__WriteTo__0__Name=Seq
-Serilog__WriteTo__0__Args__ServerUrl=http://relay_logging_seq
-BodyStore__StoragePath=/var/bodystore
-RabbitMq__ClusterHosts=relay_transport_rabbitmq1,relay_transport_rabbitmq2

--- a/src/docker/environments/relay_server_a.env
+++ b/src/docker/environments/relay_server_a.env
@@ -1,1 +1,0 @@
-Serilog__Properties__System=RelayServerA

--- a/src/docker/environments/relay_server_b.env
+++ b/src/docker/environments/relay_server_b.env
@@ -1,2 +1,0 @@
-Serilog__Properties__System=RelayServerB
-RabbitMq__Uri=amqp://relayserver:<Strong!Passw0rd>@relay_transport_rabbitmq2

--- a/src/docker/environments/relay_transport_rabbitmq.env
+++ b/src/docker/environments/relay_transport_rabbitmq.env
@@ -1,3 +1,0 @@
-RABBITMQ_DEFAULT_USER=relayserver
-RABBITMQ_DEFAULT_PASS=<Strong!Passw0rd>
-RABBITMQ_SERVER_START_ARGS="-rabbit cluster_nodes {['rabbit@relay_transport_rabbitmq1','rabbit@relay_transport_rabbitmq2'],disc} cluster_name rabbit@relay_transport"

--- a/src/docker/environments/relay_transport_rabbitmq1.env
+++ b/src/docker/environments/relay_transport_rabbitmq1.env
@@ -1,1 +1,0 @@
-RABBITMQ_NODENAME=rabbit@relay_transport_rabbitmq1

--- a/src/docker/environments/relay_transport_rabbitmq2.env
+++ b/src/docker/environments/relay_transport_rabbitmq2.env
@@ -1,1 +1,0 @@
-RABBITMQ_NODENAME=rabbit@relay_transport_rabbitmq2


### PR DESCRIPTION
Since June 2012, it has been discouraged and deprecated to use the "X-" prefix for custom headers (see https://datatracker.ietf.org/doc/html/rfc6648).

Warning: #464 needs to be merged first.